### PR TITLE
fix: force immediate dial on add-peer and introduce AddNodeCommand enum

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/FlorestaRpc.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/FlorestaRpc.kt
@@ -1,5 +1,6 @@
 package com.github.jvsena42.mandacaru.data
 
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.AddNodeResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockCountResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockHashResponse
@@ -78,9 +79,13 @@ interface FlorestaRpc {
     /**
      * Adds a new node to our list of peers. This will make our node try to connect to this peer.
      * @param node A network address with the format ip[:port]
-     * @param command One of "add" (persistent), "remove", or "onetry" (immediate one-shot dial).
+     * @param command [AddNodeCommand.ADD] (persistent), [AddNodeCommand.REMOVE], or
+     *   [AddNodeCommand.ONETRY] (immediate one-shot dial).
      */
-    fun addNode(node: String, command: String = "add"): Flow<Result<AddNodeResponse>>
+    fun addNode(
+        node: String,
+        command: AddNodeCommand = AddNodeCommand.ADD,
+    ): Flow<Result<AddNodeResponse>>
 
     /**
      * Returns the number of seconds the daemon has been running.

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaRpcImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaRpcImpl.kt
@@ -5,6 +5,7 @@ import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.domain.model.Constants
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.RpcMethods
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.AddNodeResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockCountResponse
@@ -70,9 +71,9 @@ class FlorestaRpcImpl(
     override fun listDescriptors(): Flow<Result<ListDescriptorsResponse>> =
         executeRpcCall(RpcMethods.LIST_DESCRIPTORS)
 
-    override fun addNode(node: String, command: String): Flow<Result<AddNodeResponse>> {
-        Log.d(TAG, "addNode: $node ($command)")
-        return executeRpcCall<AddNodeResponse>(RpcMethods.ADD_NODE, params = arrayOf(node, command))
+    override fun addNode(node: String, command: AddNodeCommand): Flow<Result<AddNodeResponse>> {
+        Log.d(TAG, "addNode: $node (${command.value})")
+        return executeRpcCall<AddNodeResponse>(RpcMethods.ADD_NODE, params = arrayOf(node, command.value))
             .map { result ->
                 result.fold(
                     onSuccess = { response ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnect.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnect.kt
@@ -6,6 +6,7 @@ import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.domain.model.Constants
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import kotlinx.coroutines.flow.firstOrNull
 
 // When an IBD node has zero Utreexo-flagged peers it cannot make progress, because inclusion
@@ -70,19 +71,19 @@ class UtreexoBridgeAutoConnect(
 
     private suspend fun addBridges(bridges: List<String>) {
         bridges.forEach { bridge ->
-            // "onetry" forces an immediate outbound connection attempt; "add" registers the
+            // ONETRY forces an immediate outbound connection attempt; ADD registers the
             // address in the persistent pool so Floresta retries on its own if the link drops.
-            // Without "onetry" the Rust daemon often accepts "add" without ever dialling the
+            // Without ONETRY the Rust daemon often accepts ADD without ever dialling the
             // address
-            addBridgeWith(bridge, command = "onetry")
-            addBridgeWith(bridge, command = "add")
+            addBridgeWith(bridge, AddNodeCommand.ONETRY)
+            addBridgeWith(bridge, AddNodeCommand.ADD)
         }
     }
 
-    private suspend fun addBridgeWith(bridge: String, command: String) {
+    private suspend fun addBridgeWith(bridge: String, command: AddNodeCommand) {
         val result = florestaRpc.addNode(bridge, command).firstOrNull()
-        result?.onSuccess { Log.d(TAG, "addNode($bridge, $command) ok") }
-        result?.onFailure { Log.w(TAG, "addNode($bridge, $command) failed: ${it.message}") }
+        result?.onSuccess { Log.d(TAG, "addNode($bridge, ${command.value}) ok") }
+        result?.onFailure { Log.w(TAG, "addNode($bridge, ${command.value}) failed: ${it.message}") }
     }
 
     private companion object {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/florestaRPC/AddNodeCommand.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/florestaRPC/AddNodeCommand.kt
@@ -1,0 +1,7 @@
+package com.github.jvsena42.mandacaru.domain.model.florestaRPC
+
+enum class AddNodeCommand(val value: String) {
+    ADD("add"),
+    ONETRY("onetry"),
+    REMOVE("remove"),
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
@@ -20,6 +21,7 @@ import java.io.File
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
@@ -153,22 +155,29 @@ class SettingsViewModel(
     }
 
     private fun connectNode() {
-        if (_uiState.value.nodeAddress.isEmpty()) return
+        val address = _uiState.value.nodeAddress
+        if (address.isEmpty()) return
         _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch(Dispatchers.IO) {
-            florestaRpc.addNode(_uiState.value.nodeAddress)
-                .collect { result ->
-                    result.onSuccess { data ->
-                        _uiState.update { it.copy(nodeAddress = "", snackBarMessage = "Node connected successfully") }
-                        Log.d(TAG, "connectNode: Success: $data")
-                    }.onFailure { error ->
-                        Log.d(TAG, "connectNode: Fail: ${error.message}")
-                        _uiState.update { it.copy(snackBarMessage = error.message.toString()) }
-                    }
+            val onetryResult = florestaRpc.addNode(address, AddNodeCommand.ONETRY).firstOrNull()
 
-                    delay(2.seconds)
-                    _uiState.update { it.copy(isLoading = false) }
+            onetryResult?.onSuccess { data ->
+                Log.d(TAG, "connectNode: onetry ok: $data")
+                _uiState.update {
+                    it.copy(
+                        nodeAddress = "",
+                        snackBarMessage = "Attempting connection to $address…"
+                    )
                 }
+                florestaRpc.addNode(address, AddNodeCommand.ADD).firstOrNull()
+                    ?.onFailure { Log.w(TAG, "connectNode: add (persist) failed: ${it.message}") }
+            }?.onFailure { error ->
+                Log.d(TAG, "connectNode: onetry failed: ${error.message}")
+                _uiState.update { it.copy(snackBarMessage = error.message.toString()) }
+            }
+
+            delay(2.seconds)
+            _uiState.update { it.copy(isLoading = false) }
         }
     }
 

--- a/app/src/test/java/com/github/jvsena42/mandacaru/data/floresta/AddNodeRequestTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/data/floresta/AddNodeRequestTest.kt
@@ -93,11 +93,31 @@ class AddNodeRequestTest {
         assertEquals("add", params[1].asString)
     }
 
+    @Test
+    fun `addnode request includes onetry command when forcing immediate dial`() {
+        val request = buildAddNodeRequest("189.44.63.101:8333", command = "onetry")
+        val params = request.getAsJsonArray("params")
+        assertEquals(2, params.size())
+        assertEquals("189.44.63.101:8333", params[0].asString)
+        assertEquals("onetry", params[1].asString)
+    }
+
+    @Test
+    fun `addnode params are address and command regardless of command value`() {
+        listOf("add", "onetry", "remove").forEach { command ->
+            val request = buildAddNodeRequest("194.163.132.180:8333", command = command)
+            val params = request.getAsJsonArray("params")
+            assertEquals("command=$command: params size", 2, params.size())
+            assertEquals("command=$command: address", "194.163.132.180:8333", params[0].asString)
+            assertEquals("command=$command: command", command, params[1].asString)
+        }
+    }
+
     /**
      * Builds a JSON-RPC request body the same way [FlorestaRpcImpl] does for addNode.
      */
-    private fun buildAddNodeRequest(nodeAddress: String): JsonObject {
-        val params = listOf(nodeAddress, "add")
+    private fun buildAddNodeRequest(nodeAddress: String, command: String = "add"): JsonObject {
+        val params = listOf(nodeAddress, command)
         val request = mapOf(
             "jsonrpc" to "2.0",
             "method" to "addnode",

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnectTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnectTest.kt
@@ -3,6 +3,7 @@ package com.github.jvsena42.mandacaru.domain.floresta
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.AddNodeResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockCountResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockHashResponse
@@ -38,10 +39,10 @@ class UtreexoBridgeAutoConnectTest {
 
         assertEquals(
             listOf(
-                "1.228.21.110:38333" to "onetry",
-                "1.228.21.110:38333" to "add",
-                "189.44.63.101:38333" to "onetry",
-                "189.44.63.101:38333" to "add",
+                "1.228.21.110:38333" to AddNodeCommand.ONETRY,
+                "1.228.21.110:38333" to AddNodeCommand.ADD,
+                "189.44.63.101:38333" to AddNodeCommand.ONETRY,
+                "189.44.63.101:38333" to AddNodeCommand.ADD,
             ),
             rpc.addNodeCalls
         )
@@ -141,8 +142,8 @@ class UtreexoBridgeAutoConnectTest {
 
         assertEquals(
             listOf(
-                "1.228.21.110:18333" to "onetry",
-                "1.228.21.110:18333" to "add",
+                "1.228.21.110:18333" to AddNodeCommand.ONETRY,
+                "1.228.21.110:18333" to AddNodeCommand.ADD,
             ),
             rpc.addNodeCalls
         )
@@ -169,11 +170,11 @@ private class FakePreferences(private val network: String) : PreferencesDataSour
 private class FakeFlorestaRpc(
     private val peers: List<PeerInfoResult>
 ) : FlorestaRpc {
-    val addNodeCalls = mutableListOf<Pair<String, String>>()
+    val addNodeCalls = mutableListOf<Pair<String, AddNodeCommand>>()
     var getPeerInfoCallCount = 0
         private set
 
-    override fun addNode(node: String, command: String): Flow<Result<AddNodeResponse>> {
+    override fun addNode(node: String, command: AddNodeCommand): Flow<Result<AddNodeResponse>> {
         addNodeCalls.add(node to command)
         return flowOf(Result.success(AddNodeResponse(id = 1, jsonrpc = "2.0", result = ResultAddNode(success = true))))
     }


### PR DESCRIPTION
## Summary
- Fixes [#44](https://github.com/jvsena42/mandacaru/issues/44) — Settings "Node connected successfully" snackbar fired even when the peer was never dialled. `SettingsViewModel.connectNode()` now fires `addnode <addr> onetry` (immediate dial) and then `addnode <addr> add` for persistence, mirroring the bridge-autoconnect pattern. Snackbar wording changed to `"Attempting connection to <address>…"` so the UI stops overclaiming.
- Introduces `AddNodeCommand` enum (`ADD`/`ONETRY`/`REMOVE`) alongside `RpcMethods`. `FlorestaRpc.addNode` now takes the enum instead of a raw `String`, removing the magic strings from `SettingsViewModel` and `UtreexoBridgeAutoConnect`.
- Extends `AddNodeRequestTest` with `onetry` wire-format coverage and updates `UtreexoBridgeAutoConnectTest`'s fake RPC + assertions to the enum type.

## Test plan
- [x] `./gradlew test` — all unit tests pass
- [x] Manual on ARM64 device: Settings → enter a reachable utreexod → expect `Attempting connection to <address>…` snackbar and the peer appearing in `getpeerinfo` within a few seconds
- [x] Manual on ARM64 device: Settings → enter an unreachable address (e.g. `127.0.0.1:1`) → expect failure snackbar, not a false success
- [x] Logcat sanity: single Settings submission logs both `addnode … onetry` and `addnode … add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)