### PR TITLE
fix: use luisschwab's :8433 as verified mainnet Utreexo bridge

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/Constants.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/Constants.kt
@@ -13,17 +13,20 @@ object Constants {
     const val ELECTRUM_PORT_SIGNET = "60001"
     const val ELECTRUM_PORT_REGTEST = "20001"
 
-    // Known Utreexo bridge nodes, keyed by FlorestaNetwork enum `.name` (e.g. "BITCOIN").
-    // Each entry must be a peer confirmed to advertise NODE_UTREEXO (service flag bit 12).
+    // Known Utreexo bridge nodes, keyed by FlorestaNetwork enum `.name`.
+    // Each entry must be a peer confirmed to advertise NODE_UTREEXO (bit 12).
     //
-    // BITCOIN is intentionally empty: a full v2 sweep of the 7 UTREEXO-flagged entries in
-    // Floresta/crates/floresta-wire/seeds/mainnet_seeds.json found zero live utreexo peers
-    // on mainnet (5 are unreachable; 195.26.240.213 now runs vanilla Bitcoin Core 30.0.0;
-    // Casa21's 189.44.63.101:8333 accepts TCP but never completes the v2 handshake).
-    //
-    // 1.228.21.110 (testnet:18333 / signet:38333) runs `utreexod 0.5.0` and is the only
-    // verified live Utreexo peer we found across all 7 seed-file entries.
+    // 195.26.240.213:8433 — luisschwab's Utreexo bridge (confirmed by operator
+    //   in getfloresta/Floresta#971 comment 4284241912). The :8333 entry that
+    //   appears in Floresta's mainnet_seeds.json is his regular Bitcoin Core
+    //   and should not be treated as a Utreexo peer.
+    // 1.228.21.110 — runs `utreexod 0.5.0`; advertises UTREEXO + UTREEXO_ARCHIVE
+    //   on testnet (18333) and signet (38333). Mainnet port (8333) is closed.
+    // 189.44.63.101:38333 (Casa21) — signet bridge added upstream in 7afd8d2.
     private val UTREEXO_BRIDGES: Map<String, List<String>> = mapOf(
+        "BITCOIN" to listOf(
+            "195.26.240.213:8433",
+        ),
         "SIGNET" to listOf(
             "1.228.21.110:38333",
             "189.44.63.101:38333",

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnectTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoBridgeAutoConnectTest.kt
@@ -75,16 +75,20 @@ class UtreexoBridgeAutoConnectTest {
     }
 
     @Test
-    fun `BITCOIN mainnet has no bridges until a live utreexo peer is published`() = runBlocking {
+    fun `BITCOIN mainnet fires addnode for the one verified utreexo bridge`() = runBlocking {
         val rpc = FakeFlorestaRpc(peers = emptyList())
         val prefs = FakePreferences(network = "BITCOIN")
         val sut = UtreexoBridgeAutoConnect(rpc, prefs, nowMs = { 0L })
 
         sut.ensureUtreexoPeers()
-        sut.seedOnStartup()
 
-        assertTrue(rpc.addNodeCalls.isEmpty())
-        assertEquals(0, rpc.getPeerInfoCallCount)
+        assertEquals(
+            listOf(
+                "195.26.240.213:8433" to AddNodeCommand.ONETRY,
+                "195.26.240.213:8433" to AddNodeCommand.ADD,
+            ),
+            rpc.addNodeCalls,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Re-adds `195.26.240.213:8433` to the `BITCOIN` bridge list in `Constants.kt` as the sole verified mainnet Utreexo bridge.
- Updates the block comment to reflect the actual layout of the two nodes that operator runs.
- Rewrites the `BITCOIN`-empty-list test to assert the new bridge fires `addnode onetry` + `addnode add`.

## Why
In #49 the mainnet bridge list was emptied after a v2 sweep showed the 7 seed-file entries were dead or misclassified. [Luis Schwab clarified on the upstream issue](https://github.com/getfloresta/Floresta/issues/971#issuecomment-4284241912) that his Utreexo bridge runs on **port 8433**, not 8333:

> My Utreexo bridge uses port 8433, whilst my Bitcoin Core uses 8333.
> This script was generated programmatically via a script that `dig`s the DNS seeds. So it's the case that both of my nodes were added to this list.

The `195.26.240.213:8333` entry in `mainnet_seeds.json` is his regular Bitcoin Core (which is why our probe saw `/Satoshi:30.0.0/` without `0x1000`). The actual bridge at `:8433` is already present in the seed file as entry #3. Re-listing it gives `UtreexoBridgeAutoConnect` a real mainnet target so the auto-addnode loop is no longer a no-op on mainnet.

## Test plan
- [x] `./gradlew test` — new `BITCOIN mainnet fires addnode for the one verified utreexo bridge` passes alongside existing suites.
- [x] `./gradlew detekt` — clean.
- [x] `./gradlew assembleDebug` — APK builds.
- [ ] On-device (mainnet, cleared app data): confirm `UtreexoBridgeAutoConnect: seedOnStartup: adding 1 bridge(s)` + `addNode: 195.26.240.213:8433 (ONETRY)` + `(ADD)` in `adb logcat`, and a `peer_man: New peer id=… 0x1000` on the Rust daemon side.

Closes the mainnet-target loose-end from #49.
Upstream tracking: getfloresta/Floresta#971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)