### PR TITLE
feat: Utreexo snapshot import/export — transfer validation between devices

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
 
     testImplementation(libs.junit)
+    testImplementation("org.json:json:20240303")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,13 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.androidx.datastore.preferences)
 
+    implementation(libs.zxing.core)
+    implementation(libs.androidx.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
+    implementation(libs.mlkit.barcode.scanning)
+
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.koin.viewmodel)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,11 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:name=".MandacaruApplication"

--- a/app/src/main/java/com/florestad/florestad.kt
+++ b/app/src/main/java/com/florestad/florestad.kt
@@ -396,9 +396,13 @@ internal interface UniffiLib : Library {
     ): Pointer
     fun uniffi_florestad_ffi_fn_constructor_florestad_new(uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
+    fun uniffi_florestad_ffi_fn_method_florestad_dump_utreexo_state(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     fun uniffi_florestad_ffi_fn_method_florestad_start(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     fun uniffi_florestad_ffi_fn_method_florestad_stop(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_florestad_ffi_fn_func_validate_utreexo_snapshot_json(`payload`: RustBuffer.ByValue,`expectedNetwork`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     fun ffi_florestad_ffi_rustbuffer_alloc(`size`: Int,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -512,6 +516,10 @@ internal interface UniffiLib : Library {
     ): Unit
     fun ffi_florestad_ffi_rust_future_complete_void(`handle`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    fun uniffi_florestad_ffi_checksum_func_validate_utreexo_snapshot_json(
+    ): Short
+    fun uniffi_florestad_ffi_checksum_method_florestad_dump_utreexo_state(
+    ): Short
     fun uniffi_florestad_ffi_checksum_method_florestad_start(
     ): Short
     fun uniffi_florestad_ffi_checksum_method_florestad_stop(
@@ -537,6 +545,12 @@ private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: UniffiLib) {
+    if (lib.uniffi_florestad_ffi_checksum_func_validate_utreexo_snapshot_json() != 55281.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_florestad_ffi_checksum_method_florestad_dump_utreexo_state() != 63731.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_florestad_ffi_checksum_method_florestad_start() != 38627.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -914,6 +928,8 @@ object NoPointer
 
 public interface FlorestadInterface {
     
+    fun `dumpUtreexoState`(): String
+    
     fun `start`()
     
     fun `stop`()
@@ -960,6 +976,18 @@ open class Florestad : FFIObject, FlorestadInterface {
         }
     }
 
+    
+    @Throws(UtreexoExportException::class)override fun `dumpUtreexoState`(): String =
+        callWithPointer {
+    uniffiRustCallWithError(UtreexoExportException) { _status ->
+    UniffiLib.INSTANCE.uniffi_florestad_ffi_fn_method_florestad_dump_utreexo_state(it,
+        
+        _status)
+}
+        }.let {
+            FfiConverterString.lift(it)
+        }
+    
     override fun `start`() =
         callWithPointer {
     uniffiRustCall() { _status ->
@@ -1029,7 +1057,8 @@ data class Config (
     var `walletXpub`: String? = null, 
     var `walletDescriptor`: String? = null, 
     var `filtersStartHeight`: Int? = null, 
-    var `assumeUtreexo`: Boolean = false
+    var `assumeUtreexo`: Boolean = false, 
+    var `userUtreexoSnapshotJson`: String? = null
 ) {
     
     companion object
@@ -1046,6 +1075,7 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalInt.read(buf),
             FfiConverterBoolean.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -1057,7 +1087,8 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalString.allocationSize(value.`walletXpub`) +
             FfiConverterOptionalString.allocationSize(value.`walletDescriptor`) +
             FfiConverterOptionalInt.allocationSize(value.`filtersStartHeight`) +
-            FfiConverterBoolean.allocationSize(value.`assumeUtreexo`)
+            FfiConverterBoolean.allocationSize(value.`assumeUtreexo`) +
+            FfiConverterOptionalString.allocationSize(value.`userUtreexoSnapshotJson`)
     )
 
     override fun write(value: Config, buf: ByteBuffer) {
@@ -1069,6 +1100,7 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalString.write(value.`walletDescriptor`, buf)
             FfiConverterOptionalInt.write(value.`filtersStartHeight`, buf)
             FfiConverterBoolean.write(value.`assumeUtreexo`, buf)
+            FfiConverterOptionalString.write(value.`userUtreexoSnapshotJson`, buf)
     }
 }
 
@@ -1099,6 +1131,126 @@ public object FfiConverterTypeNetwork: FfiConverterRustBuffer<Network> {
 }
 
 
+
+
+
+
+
+sealed class UtreexoExportException(message: String): Exception(message) {
+        
+        class NotStarted(message: String) : UtreexoExportException(message)
+        
+        class NotSynced(message: String) : UtreexoExportException(message)
+        
+        class Internal(message: String) : UtreexoExportException(message)
+        
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<UtreexoExportException> {
+        override fun lift(error_buf: RustBuffer.ByValue): UtreexoExportException = FfiConverterTypeUtreexoExportError.lift(error_buf)
+    }
+}
+
+public object FfiConverterTypeUtreexoExportError : FfiConverterRustBuffer<UtreexoExportException> {
+    override fun read(buf: ByteBuffer): UtreexoExportException {
+        
+            return when(buf.getInt()) {
+            1 -> UtreexoExportException.NotStarted(FfiConverterString.read(buf))
+            2 -> UtreexoExportException.NotSynced(FfiConverterString.read(buf))
+            3 -> UtreexoExportException.Internal(FfiConverterString.read(buf))
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+        
+    }
+
+    override fun allocationSize(value: UtreexoExportException): Int {
+        return 4
+    }
+
+    override fun write(value: UtreexoExportException, buf: ByteBuffer) {
+        when(value) {
+            is UtreexoExportException.NotStarted -> {
+                buf.putInt(1)
+                Unit
+            }
+            is UtreexoExportException.NotSynced -> {
+                buf.putInt(2)
+                Unit
+            }
+            is UtreexoExportException.Internal -> {
+                buf.putInt(3)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
+
+
+
+
+
+sealed class UtreexoImportException(message: String): Exception(message) {
+        
+        class InvalidJson(message: String) : UtreexoImportException(message)
+        
+        class UnsupportedVersion(message: String) : UtreexoImportException(message)
+        
+        class UnknownNetwork(message: String) : UtreexoImportException(message)
+        
+        class InvalidHex(message: String) : UtreexoImportException(message)
+        
+        class NetworkMismatch(message: String) : UtreexoImportException(message)
+        
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<UtreexoImportException> {
+        override fun lift(error_buf: RustBuffer.ByValue): UtreexoImportException = FfiConverterTypeUtreexoImportError.lift(error_buf)
+    }
+}
+
+public object FfiConverterTypeUtreexoImportError : FfiConverterRustBuffer<UtreexoImportException> {
+    override fun read(buf: ByteBuffer): UtreexoImportException {
+        
+            return when(buf.getInt()) {
+            1 -> UtreexoImportException.InvalidJson(FfiConverterString.read(buf))
+            2 -> UtreexoImportException.UnsupportedVersion(FfiConverterString.read(buf))
+            3 -> UtreexoImportException.UnknownNetwork(FfiConverterString.read(buf))
+            4 -> UtreexoImportException.InvalidHex(FfiConverterString.read(buf))
+            5 -> UtreexoImportException.NetworkMismatch(FfiConverterString.read(buf))
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+        
+    }
+
+    override fun allocationSize(value: UtreexoImportException): Int {
+        return 4
+    }
+
+    override fun write(value: UtreexoImportException, buf: ByteBuffer) {
+        when(value) {
+            is UtreexoImportException.InvalidJson -> {
+                buf.putInt(1)
+                Unit
+            }
+            is UtreexoImportException.UnsupportedVersion -> {
+                buf.putInt(2)
+                Unit
+            }
+            is UtreexoImportException.UnknownNetwork -> {
+                buf.putInt(3)
+                Unit
+            }
+            is UtreexoImportException.InvalidHex -> {
+                buf.putInt(4)
+                Unit
+            }
+            is UtreexoImportException.NetworkMismatch -> {
+                buf.putInt(5)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
 
 
 
@@ -1157,4 +1309,13 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<String?> {
         }
     }
 }
+@Throws(UtreexoImportException::class)
+
+fun `validateUtreexoSnapshotJson`(`payload`: String, `expectedNetwork`: Network) =
+    
+    uniffiRustCallWithError(UtreexoImportException) { _status ->
+    UniffiLib.INSTANCE.uniffi_florestad_ffi_fn_func_validate_utreexo_snapshot_json(FfiConverterString.lower(`payload`),FfiConverterTypeNetwork.lower(`expectedNetwork`),_status)
+}
+
+
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
@@ -13,6 +13,7 @@ import com.github.jvsena42.mandacaru.data.floresta.FlorestaDaemonImpl
 import com.github.jvsena42.mandacaru.data.floresta.FlorestaRpcImpl
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
+import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.BlockchainViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.NodeViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.transaction.TransactionViewModel
@@ -46,7 +47,14 @@ class MandacaruApplication : Application() {
 }
 
 val presentationModule = module {
-    viewModel { NodeViewModel(florestaRpc = get()) }
+    viewModel {
+        NodeViewModel(
+            florestaRpc = get(),
+            snapshotService = get(),
+            florestaDaemon = get(),
+            preferencesDataSource = get(),
+        )
+    }
     viewModel { SettingsViewModel(florestaRpc = get(), preferencesDataSource = get(), context = androidContext()) }
     viewModel { TransactionViewModel(florestaRpc = get()) }
     viewModel { BlockchainViewModel(florestaRpc = get()) }
@@ -66,4 +74,5 @@ val dataModule = module {
         )
     }
     single { UtreexoBridgeAutoConnect(florestaRpc = get(), preferencesDataSource = get()) }
+    single { UtreexoSnapshotService(daemon = get()) }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
@@ -6,5 +6,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 enum class PreferenceKeys(val dataStoreKey: Preferences.Key<String>) {
     CURRENT_NETWORK(stringPreferencesKey("CURRENT_NETWORK")),
     CURRENT_RPC_PORT(stringPreferencesKey("CURRENT_RPC_PORT")),
-    FAST_SYNC_ENABLED(stringPreferencesKey("FAST_SYNC_ENABLED"))
+    FAST_SYNC_ENABLED(stringPreferencesKey("FAST_SYNC_ENABLED")),
+    PENDING_UTREEXO_SNAPSHOT(stringPreferencesKey("PENDING_UTREEXO_SNAPSHOT"))
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -90,13 +90,6 @@ class FlorestaDaemonImpl(
                 IllegalStateException("Daemon is still running; call stop() first")
             )
         }
-        // We deliberately do NOT wipe chaindata/ or cfilters/. The core's
-        // `mark_chain_as_assumed` overlays the user-supplied accumulator on top
-        // of whatever headers the chain already has; preserving the existing
-        // chain store lets header re-sync start from the last known height
-        // (not from genesis), which is the whole point of passing a snapshot.
-        // If the chain is already past the snapshot height the core treats the
-        // assume as a no-op and the user doesn't regress.
         val base = File(datadir)
         listOf("chaindata", "cfilters").forEach { sub ->
             val dir = File(base, sub)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -5,9 +5,10 @@ import com.florestad.Config
 import com.florestad.Florestad
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
-import com.github.jvsena42.mandacaru.domain.model.Constants
-import com.github.jvsena42.mandacaru.BuildConfig
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 import com.florestad.Network as FlorestaNetwork
 
@@ -20,17 +21,15 @@ class FlorestaDaemonImpl(
     private var daemon: Florestad? = null
 
     override suspend fun start() {
-        Log.d(TAG, "start: ")
-        if (isRunning) {
-            Log.d(TAG, "start: Daemon already running")
-            return
-        }
+        if (isRunning) return
         try {
-            Log.d(TAG, "start: datadir: $datadir")
             val fastSyncEnabled = preferencesDataSource.getBoolean(
                 PreferenceKeys.FAST_SYNC_ENABLED,
                 false
             )
+            val pendingSnapshot = preferencesDataSource
+                .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
+                .takeIf { it.isNotEmpty() }
             val config = Config(
                 dataDir = datadir,
                 network = preferencesDataSource.getString(
@@ -38,6 +37,7 @@ class FlorestaDaemonImpl(
                     FlorestaNetwork.BITCOIN.name
                 ).toFlorestaNetwork(),
                 assumeUtreexo = fastSyncEnabled,
+                userUtreexoSnapshotJson = pendingSnapshot,
             )
             daemon = Florestad.fromConfig(config)
             daemon?.start()?.also {
@@ -51,15 +51,9 @@ class FlorestaDaemonImpl(
     }
 
     override suspend fun stop() {
-        Log.d(TAG, "stop: isRunning=$isRunning")
-        if (!isRunning) {
-            Log.d(TAG, "stop: Daemon not running, nothing to stop")
-            return
-        }
-
+        if (!isRunning) return
         try {
             daemon?.stop()
-            Log.i(TAG, "stop: Floresta daemon stopped successfully")
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             Log.e(TAG, "stop error: ", e)
         } finally {
@@ -69,6 +63,31 @@ class FlorestaDaemonImpl(
     }
 
     override fun isRunning(): Boolean = isRunning
+
+    override suspend fun dumpUtreexoState(): Result<String> = withContext(Dispatchers.IO) {
+        val d = daemon
+        if (!isRunning || d == null) {
+            return@withContext Result.failure(IllegalStateException("Daemon not running"))
+        }
+        runCatching { d.dumpUtreexoState() }
+    }
+
+    override suspend fun prepareForSnapshotImport(): Result<Unit> = withContext(Dispatchers.IO) {
+        if (isRunning) {
+            return@withContext Result.failure(
+                IllegalStateException("Daemon is still running; call stop() first")
+            )
+        }
+        runCatching {
+            val base = File(datadir)
+            listOf("chaindata", "cfilters").forEach { sub ->
+                val dir = File(base, sub)
+                if (dir.exists() && !dir.deleteRecursively()) {
+                    error("Failed to wipe $sub")
+                }
+            }
+        }
+    }
 
     companion object {
         private const val TAG = "FlorestaDaemonImpl"

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -90,21 +90,20 @@ class FlorestaDaemonImpl(
                 IllegalStateException("Daemon is still running; call stop() first")
             )
         }
-        runCatching {
-            val base = File(datadir)
-            listOf("chaindata", "cfilters").forEach { sub ->
-                val dir = File(base, sub)
-                val existed = dir.exists()
-                val sizeBefore = if (existed) dirSize(dir) else 0L
-                val deleted = !existed || dir.deleteRecursively()
-                Log.i(
-                    TAG,
-                    "prepareForSnapshotImport: $sub existed=$existed " +
-                        "size=$sizeBefore deleted=$deleted",
-                )
-                if (existed && !deleted) error("Failed to wipe $sub")
-            }
+        // We deliberately do NOT wipe chaindata/ or cfilters/. The core's
+        // `mark_chain_as_assumed` overlays the user-supplied accumulator on top
+        // of whatever headers the chain already has; preserving the existing
+        // chain store lets header re-sync start from the last known height
+        // (not from genesis), which is the whole point of passing a snapshot.
+        // If the chain is already past the snapshot height the core treats the
+        // assume as a no-op and the user doesn't regress.
+        val base = File(datadir)
+        listOf("chaindata", "cfilters").forEach { sub ->
+            val dir = File(base, sub)
+            val size = if (dir.exists()) dirSize(dir) else 0L
+            Log.i(TAG, "prepareForSnapshotImport: preserving $sub (size=$size)")
         }
+        Result.success(Unit)
     }
 
     private fun dirSize(dir: File): Long =

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -30,18 +30,30 @@ class FlorestaDaemonImpl(
             val pendingSnapshot = preferencesDataSource
                 .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
                 .takeIf { it.isNotEmpty() }
+            val network = preferencesDataSource.getString(
+                PreferenceKeys.CURRENT_NETWORK,
+                FlorestaNetwork.BITCOIN.name
+            ).toFlorestaNetwork()
+            val effectiveAssumeUtreexo = fastSyncEnabled || pendingSnapshot != null
+            Log.i(
+                TAG,
+                "start: pendingSnapshot=${pendingSnapshot?.length ?: 0} chars, " +
+                    "fastSync=$fastSyncEnabled→$effectiveAssumeUtreexo, " +
+                    "network=$network, datadir=$datadir",
+            )
             val config = Config(
                 dataDir = datadir,
-                network = preferencesDataSource.getString(
-                    PreferenceKeys.CURRENT_NETWORK,
-                    FlorestaNetwork.BITCOIN.name
-                ).toFlorestaNetwork(),
-                assumeUtreexo = fastSyncEnabled,
+                network = network,
+                assumeUtreexo = effectiveAssumeUtreexo,
                 userUtreexoSnapshotJson = pendingSnapshot,
             )
             daemon = Florestad.fromConfig(config)
             daemon?.start()?.also {
-                Log.i(TAG, "start: Floresta running with config $config")
+                Log.i(
+                    TAG,
+                    "start: Floresta running (pendingSnapshot=${pendingSnapshot != null}, " +
+                        "assumeUtreexo=$effectiveAssumeUtreexo)",
+                )
                 isRunning = true
             }
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -82,12 +94,21 @@ class FlorestaDaemonImpl(
             val base = File(datadir)
             listOf("chaindata", "cfilters").forEach { sub ->
                 val dir = File(base, sub)
-                if (dir.exists() && !dir.deleteRecursively()) {
-                    error("Failed to wipe $sub")
-                }
+                val existed = dir.exists()
+                val sizeBefore = if (existed) dirSize(dir) else 0L
+                val deleted = !existed || dir.deleteRecursively()
+                Log.i(
+                    TAG,
+                    "prepareForSnapshotImport: $sub existed=$existed " +
+                        "size=$sizeBefore deleted=$deleted",
+                )
+                if (existed && !deleted) error("Failed to wipe $sub")
             }
         }
     }
+
+    private fun dirSize(dir: File): Long =
+        dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
 
     companion object {
         private const val TAG = "FlorestaDaemonImpl"

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/FlorestaDaemon.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/FlorestaDaemon.kt
@@ -4,4 +4,9 @@ interface FlorestaDaemon {
     suspend fun start()
     suspend fun stop()
     fun isRunning(): Boolean
+
+    suspend fun dumpUtreexoState(): Result<String>
+
+    /** Must be called after [stop] has returned. Wipes chaindata + cfilters, preserves the wallet DB. */
+    suspend fun prepareForSnapshotImport(): Result<Unit>
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.domain.floresta
 
 import com.florestad.Network
 import com.florestad.validateUtreexoSnapshotJson
+import com.github.jvsena42.mandacaru.presentation.utils.SnapshotCodec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -16,15 +17,19 @@ data class SnapshotPreview(
 class UtreexoSnapshotService(
     private val daemon: FlorestaDaemon,
 ) {
-    suspend fun dump(): Result<String> = daemon.dumpUtreexoState()
+    suspend fun dump(): Result<String> =
+        daemon.dumpUtreexoState().mapCatching { SnapshotCodec.encodeCompact(it) }
 
     suspend fun validate(payload: String, expectedNetwork: Network) =
         withContext(Dispatchers.IO) {
-            runCatching { validateUtreexoSnapshotJson(payload, expectedNetwork) }
+            runCatching {
+                val json = SnapshotCodec.normalizeToJson(payload)
+                validateUtreexoSnapshotJson(json, expectedNetwork)
+            }
         }
 
     fun peek(payload: String): Result<SnapshotPreview> = runCatching {
-        val obj = JSONObject(payload)
+        val obj = JSONObject(SnapshotCodec.normalizeToJson(payload))
         val network = networkTagToEnum(obj.getString(KEY_NETWORK))
             ?: error("Unknown network tag")
         SnapshotPreview(

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
@@ -1,0 +1,53 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import com.florestad.Network
+import com.florestad.validateUtreexoSnapshotJson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+data class SnapshotPreview(
+    val network: Network,
+    val height: Long,
+    val blockHash: String,
+    val rootCount: Int,
+)
+
+class UtreexoSnapshotService(
+    private val daemon: FlorestaDaemon,
+) {
+    suspend fun dump(): Result<String> = daemon.dumpUtreexoState()
+
+    suspend fun validate(payload: String, expectedNetwork: Network) =
+        withContext(Dispatchers.IO) {
+            runCatching { validateUtreexoSnapshotJson(payload, expectedNetwork) }
+        }
+
+    fun peek(payload: String): Result<SnapshotPreview> = runCatching {
+        val obj = JSONObject(payload)
+        val network = networkTagToEnum(obj.getString(KEY_NETWORK))
+            ?: error("Unknown network tag")
+        SnapshotPreview(
+            network = network,
+            height = obj.getLong(KEY_HEIGHT),
+            blockHash = obj.getString(KEY_BLOCK_HASH),
+            rootCount = obj.getJSONArray(KEY_ROOTS).length(),
+        )
+    }
+
+    private fun networkTagToEnum(tag: String): Network? = when (tag) {
+        "bitcoin" -> Network.BITCOIN
+        "signet" -> Network.SIGNET
+        "testnet" -> Network.TESTNET
+        "testnet4" -> Network.TESTNET4
+        "regtest" -> Network.REGTEST
+        else -> null
+    }
+
+    private companion object {
+        const val KEY_NETWORK = "network"
+        const val KEY_HEIGHT = "height"
+        const val KEY_BLOCK_HASH = "block_hash"
+        const val KEY_ROOTS = "roots"
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
@@ -251,7 +251,7 @@ private fun MainScreen(
         ) { page ->
             when (pages[page]) {
                 Destinations.TRANSACTION -> ScreenTransaction()
-                Destinations.NODE -> ScreenNode()
+                Destinations.NODE -> ScreenNode(restartApplication = restartApplication)
                 Destinations.BLOCKCHAIN -> ScreenBlockchain()
                 Destinations.SETTINGS -> ScreenSettings(
                     restartApplication = restartApplication

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeEvents.kt
@@ -1,0 +1,6 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+sealed interface NodeEvents {
+    data object OnSnapshotApplied : NodeEvents
+    data class OnShareAccumulator(val payload: String) : NodeEvents
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -1,6 +1,7 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 
 import androidx.compose.runtime.Stable
+import com.github.jvsena42.mandacaru.domain.floresta.SnapshotPreview
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 
 @Stable
@@ -22,4 +23,14 @@ data class NodeUiState(
     val memoryFree: String = "",
     val memoryTotal: String = "",
     val isDiagnosticsExpanded: Boolean = false,
+
+    val isScanSheetOpen: Boolean = false,
+    val isPasteSheetOpen: Boolean = false,
+    val isExportQrSheetOpen: Boolean = false,
+    val isExportCardExpanded: Boolean = false,
+    val pendingSnapshotPreview: SnapshotPreview? = null,
+    val pendingSnapshotPayload: String? = null,
+    val exportPayload: String? = null,
+    val snapshotMessage: String? = null,
+    val isApplyingSnapshot: Boolean = false,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -27,6 +27,7 @@ data class NodeUiState(
     val isScanSheetOpen: Boolean = false,
     val isPasteSheetOpen: Boolean = false,
     val isExportQrSheetOpen: Boolean = false,
+    val isImportCardExpanded: Boolean = true,
     val isExportCardExpanded: Boolean = false,
     val pendingSnapshotPreview: SnapshotPreview? = null,
     val pendingSnapshotPayload: String? = null,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -3,8 +3,16 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.florestad.UtreexoImportException
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.data.floresta.toFlorestaNetwork
+import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
+import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
 import com.github.jvsena42.mandacaru.domain.floresta.hasUtreexoServiceFlag
+import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
+import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
 import com.github.jvsena42.mandacaru.presentation.utils.toHumanReadableDifficulty
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -14,10 +22,14 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
 import kotlin.time.Duration.Companion.seconds
+import com.florestad.Network as FlorestaNetwork
 
 class NodeViewModel(
-    private val florestaRpc: FlorestaRpc
-) : ViewModel() {
+    private val florestaRpc: FlorestaRpc,
+    private val snapshotService: UtreexoSnapshotService,
+    private val florestaDaemon: FlorestaDaemon,
+    private val preferencesDataSource: PreferencesDataSource,
+) : ViewModel(), EventFlow<NodeEvents> by EventFlowImpl() {
 
     private val _uiState = MutableStateFlow(NodeUiState())
     val uiState = _uiState.asStateFlow()
@@ -38,7 +50,6 @@ class NodeViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             florestaRpc.getBlockchainInfo().collect { result ->
                 result.onSuccess { data ->
-                    Log.d(TAG, "getBlockchainInfo: $data")
                     _uiState.update {
                         it.copy(
                             blockHeight = NumberFormat.getNumberInstance().format(data.result.height),
@@ -50,6 +61,9 @@ class NodeViewModel(
                             validatedBLocks = data.result.validated,
                             ibd = data.result.ibd
                         )
+                    }
+                    if (!data.result.ibd) {
+                        clearPendingSnapshotIfAny()
                     }
                 }
                 updatePeerInfo()
@@ -110,10 +124,7 @@ class NodeViewModel(
     fun disconnectPeer(address: String) {
         viewModelScope.launch(Dispatchers.IO) {
             florestaRpc.disconnectNode(address).collect { result ->
-                result.onSuccess {
-                    Log.d(TAG, "disconnectPeer success: $address")
-                    updatePeerInfo()
-                }
+                result.onSuccess { updatePeerInfo() }
                 result.onFailure { e ->
                     Log.e(TAG, "disconnectPeer failure: ${e.message}")
                 }
@@ -124,7 +135,6 @@ class NodeViewModel(
     fun pingPeers() {
         viewModelScope.launch(Dispatchers.IO) {
             florestaRpc.ping().collect { result ->
-                result.onSuccess { Log.d(TAG, "ping success") }
                 result.onFailure { e -> Log.e(TAG, "ping failure: ${e.message}") }
             }
         }
@@ -132,7 +142,6 @@ class NodeViewModel(
 
     private suspend fun updatePeerInfo() {
         florestaRpc.getPeerInfo().collect { result ->
-            Log.d(TAG, "getPeerInfo: ${result.getOrNull()}")
             result.onSuccess { data ->
                 val peers = data.result.orEmpty()
                 _uiState.update {
@@ -146,6 +155,161 @@ class NodeViewModel(
         }
     }
 
+    fun onClickScan() {
+        if (!_uiState.value.ibd) return
+        _uiState.update { it.copy(isScanSheetOpen = true) }
+    }
+
+    fun onClickPaste() {
+        if (!_uiState.value.ibd) return
+        _uiState.update { it.copy(isPasteSheetOpen = true) }
+    }
+
+    fun onDismissScanSheet() {
+        _uiState.update { it.copy(isScanSheetOpen = false) }
+    }
+
+    fun onDismissPasteSheet() {
+        _uiState.update { it.copy(isPasteSheetOpen = false) }
+    }
+
+    fun onAccumulatorReceived(payload: String) {
+        if (!_uiState.value.ibd) return
+        _uiState.update {
+            it.copy(isScanSheetOpen = false, isPasteSheetOpen = false)
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentNetworkEnum = currentNetwork()
+            snapshotService.validate(payload, currentNetworkEnum).onFailure { error ->
+                _uiState.update {
+                    it.copy(snapshotMessage = errorToMessage(error, currentNetworkEnum))
+                }
+                return@launch
+            }
+            val preview = snapshotService.peek(payload)
+            preview.onFailure {
+                _uiState.update { it.copy(snapshotMessage = "Unrecognised snapshot format.") }
+                return@launch
+            }
+            _uiState.update {
+                it.copy(
+                    pendingSnapshotPreview = preview.getOrNull(),
+                    pendingSnapshotPayload = payload,
+                )
+            }
+        }
+    }
+
+    fun onDismissImportConfirm() {
+        _uiState.update {
+            it.copy(pendingSnapshotPreview = null, pendingSnapshotPayload = null)
+        }
+    }
+
+    fun onConfirmImport() {
+        val payload = _uiState.value.pendingSnapshotPayload ?: return
+        if (!_uiState.value.ibd) return
+        _uiState.update {
+            it.copy(
+                isApplyingSnapshot = true,
+                pendingSnapshotPreview = null,
+                pendingSnapshotPayload = null,
+            )
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesDataSource.setString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, payload)
+            florestaDaemon.stop()
+            florestaDaemon.prepareForSnapshotImport()
+                .onFailure { error ->
+                    Log.e(TAG, "prepareForSnapshotImport failed", error)
+                    _uiState.update {
+                        it.copy(
+                            isApplyingSnapshot = false,
+                            snapshotMessage = "Failed to prepare for import: ${error.message}",
+                        )
+                    }
+                    return@launch
+                }
+            with(viewModelScope) { sendEvent(NodeEvents.OnSnapshotApplied) }
+        }
+    }
+
+    fun toggleExportCardExpanded() {
+        if (_uiState.value.ibd) return
+        _uiState.update { it.copy(isExportCardExpanded = !it.isExportCardExpanded) }
+    }
+
+    fun onClickShowExportQr() = withExportPayload { payload ->
+        _uiState.update { it.copy(isExportQrSheetOpen = true, exportPayload = payload) }
+    }
+
+    fun onClickCopyExport() = withExportPayload { payload ->
+        _uiState.update {
+            it.copy(exportPayload = payload, snapshotMessage = COPIED_MESSAGE)
+        }
+    }
+
+    fun onClickShareExport() = withExportPayload { payload ->
+        _uiState.update { it.copy(exportPayload = payload) }
+        with(viewModelScope) { sendEvent(NodeEvents.OnShareAccumulator(payload)) }
+    }
+
+    fun onDismissExportQrSheet() {
+        _uiState.update { it.copy(isExportQrSheetOpen = false) }
+    }
+
+    fun clearSnapshotMessage() {
+        _uiState.update { it.copy(snapshotMessage = null) }
+    }
+
+    private fun withExportPayload(then: (String) -> Unit) {
+        if (_uiState.value.ibd) return
+        val cached = _uiState.value.exportPayload
+        if (cached != null) {
+            then(cached)
+            return
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            snapshotService.dump()
+                .onSuccess { then(it) }
+                .onFailure { error ->
+                    Log.w(TAG, "dumpUtreexoState failed", error)
+                    _uiState.update {
+                        it.copy(snapshotMessage = "Could not export snapshot: ${error.message}")
+                    }
+                }
+        }
+    }
+
+    private suspend fun currentNetwork(): FlorestaNetwork {
+        return preferencesDataSource.getString(
+            PreferenceKeys.CURRENT_NETWORK,
+            FlorestaNetwork.BITCOIN.name,
+        ).toFlorestaNetwork()
+    }
+
+    private suspend fun clearPendingSnapshotIfAny() {
+        val existing = preferencesDataSource
+            .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
+        if (existing.isNotEmpty()) {
+            preferencesDataSource.setString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
+        }
+    }
+
+    private fun errorToMessage(error: Throwable, currentNetwork: FlorestaNetwork): String =
+        when (error) {
+            is UtreexoImportException.NetworkMismatch ->
+                "This snapshot is for a different network than this node ($currentNetwork)."
+            is UtreexoImportException.UnsupportedVersion ->
+                "This snapshot uses a newer format than this app supports."
+            is UtreexoImportException.InvalidHex ->
+                "Snapshot contains malformed data."
+            is UtreexoImportException.UnknownNetwork,
+            is UtreexoImportException.InvalidJson ->
+                "Unrecognised snapshot format."
+            else -> error.message ?: "Snapshot import failed."
+        }
+
     private companion object {
         const val TAG = "NodeViewModel"
         const val PERCENTAGE_MULTIPLIER = 100
@@ -154,5 +318,6 @@ class NodeViewModel(
         const val SECONDS_PER_MINUTE = 60L
         const val BYTES_PER_KB = 1_024L
         const val BYTES_PER_MB = 1_048_576L
+        const val COPIED_MESSAGE = "Copied to clipboard"
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -218,6 +218,11 @@ class NodeViewModel(
             )
         }
         viewModelScope.launch(Dispatchers.IO) {
+            Log.i(
+                TAG,
+                "onConfirmImport: payload len=${payload.length} " +
+                    "compact=${SnapshotCodec.isCompact(payload)}",
+            )
             val payloadToPersist = runCatching { SnapshotCodec.normalizeToJson(payload) }
                 .getOrElse { error ->
                     Log.e(TAG, "normalizeToJson failed", error)
@@ -229,10 +234,26 @@ class NodeViewModel(
                     }
                     return@launch
                 }
+            Log.i(
+                TAG,
+                "onConfirmImport: normalized JSON len=${payloadToPersist.length} " +
+                    "digest=${sha256Short(payloadToPersist)}",
+            )
             preferencesDataSource.setString(
                 PreferenceKeys.PENDING_UTREEXO_SNAPSHOT,
                 payloadToPersist,
             )
+            val readBack = preferencesDataSource
+                .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
+            if (readBack.length != payloadToPersist.length) {
+                Log.e(
+                    TAG,
+                    "onConfirmImport: DataStore read-back MISMATCH " +
+                        "wrote=${payloadToPersist.length} read=${readBack.length}",
+                )
+            } else {
+                Log.i(TAG, "onConfirmImport: setString OK, read-back len=${readBack.length}")
+            }
             florestaDaemon.stop()
             florestaDaemon.prepareForSnapshotImport()
                 .onFailure { error ->
@@ -245,6 +266,7 @@ class NodeViewModel(
                     }
                     return@launch
                 }
+            Log.i(TAG, "onConfirmImport: OK — restart pending")
             with(viewModelScope) { sendEvent(NodeEvents.OnSnapshotApplied) }
         }
     }
@@ -312,8 +334,26 @@ class NodeViewModel(
         val existing = preferencesDataSource
             .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
         if (existing.isNotEmpty()) {
+            Log.i(TAG, "clearPendingSnapshotIfAny: clearing ${existing.length}-char snapshot (ibd=false)")
             preferencesDataSource.setString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
         }
+    }
+
+    private fun sha256Short(s: String): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray())
+        val sb = StringBuilder(16)
+        for (i in 0 until 4) {
+            val b = digest[i].toInt() and 0xFF
+            sb.append("0123456789abcdef"[b ushr 4])
+            sb.append("0123456789abcdef"[b and 0x0F])
+        }
+        sb.append("..")
+        for (i in digest.size - 4 until digest.size) {
+            val b = digest[i].toInt() and 0xFF
+            sb.append("0123456789abcdef"[b ushr 4])
+            sb.append("0123456789abcdef"[b and 0x0F])
+        }
+        return sb.toString()
     }
 
     private fun errorToMessage(error: Throwable, currentNetwork: FlorestaNetwork): String =

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -13,6 +13,7 @@ import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
 import com.github.jvsena42.mandacaru.domain.floresta.hasUtreexoServiceFlag
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
+import com.github.jvsena42.mandacaru.presentation.utils.SnapshotCodec
 import com.github.jvsena42.mandacaru.presentation.utils.toHumanReadableDifficulty
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -217,7 +218,21 @@ class NodeViewModel(
             )
         }
         viewModelScope.launch(Dispatchers.IO) {
-            preferencesDataSource.setString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, payload)
+            val payloadToPersist = runCatching { SnapshotCodec.normalizeToJson(payload) }
+                .getOrElse { error ->
+                    Log.e(TAG, "normalizeToJson failed", error)
+                    _uiState.update {
+                        it.copy(
+                            isApplyingSnapshot = false,
+                            snapshotMessage = "Snapshot payload was unreadable.",
+                        )
+                    }
+                    return@launch
+                }
+            preferencesDataSource.setString(
+                PreferenceKeys.PENDING_UTREEXO_SNAPSHOT,
+                payloadToPersist,
+            )
             florestaDaemon.stop()
             florestaDaemon.prepareForSnapshotImport()
                 .onFailure { error ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -234,6 +234,11 @@ class NodeViewModel(
         }
     }
 
+    fun toggleImportCardExpanded() {
+        if (!_uiState.value.ibd) return
+        _uiState.update { it.copy(isImportCardExpanded = !it.isImportCardExpanded) }
+    }
+
     fun toggleExportCardExpanded() {
         if (_uiState.value.ibd) return
         _uiState.update { it.copy(isExportCardExpanded = !it.isExportCardExpanded) }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -17,6 +17,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import android.content.Intent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Hub
@@ -62,18 +72,68 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun ScreenNode(
+    restartApplication: () -> Unit = {},
     viewModel: NodeViewModel = koinViewModel()
 ) {
     RequestNotificationPermissions(onPermissionChange = {})
 
     val uiState by viewModel.uiState.collectAsState()
-    ScreenNode(
-        uiState = uiState,
-        onTogglePeers = viewModel::togglePeersExpanded,
-        onToggleDiagnostics = viewModel::toggleDiagnosticsExpanded,
-        onDisconnectPeer = viewModel::disconnectPeer,
-        onPingPeers = viewModel::pingPeers
-    )
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        viewModel.eventFlow.collect { event ->
+            when (event) {
+                NodeEvents.OnSnapshotApplied -> restartApplication()
+                is NodeEvents.OnShareAccumulator -> {
+                    val share = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, event.payload)
+                    }
+                    context.startActivity(Intent.createChooser(share, null))
+                }
+            }
+        }
+    }
+
+    val message = uiState.snapshotMessage
+    LaunchedEffect(message) {
+        if (message != null) {
+            snackbarHostState.showSnackbar(message)
+            viewModel.clearSnapshotMessage()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { padding ->
+        ScreenNode(
+            uiState = uiState,
+            modifier = Modifier.padding(padding),
+            onTogglePeers = viewModel::togglePeersExpanded,
+            onToggleDiagnostics = viewModel::toggleDiagnosticsExpanded,
+            onDisconnectPeer = viewModel::disconnectPeer,
+            onPingPeers = viewModel::pingPeers,
+            onClickScan = viewModel::onClickScan,
+            onClickPaste = viewModel::onClickPaste,
+            onDismissScanSheet = viewModel::onDismissScanSheet,
+            onDismissPasteSheet = viewModel::onDismissPasteSheet,
+            onAccumulatorReceived = viewModel::onAccumulatorReceived,
+            onDismissImportConfirm = viewModel::onDismissImportConfirm,
+            onConfirmImport = viewModel::onConfirmImport,
+            onToggleExportCard = viewModel::toggleExportCardExpanded,
+            onClickShowExportQr = viewModel::onClickShowExportQr,
+            onClickCopyExport = {
+                viewModel.onClickCopyExport()
+                uiState.exportPayload?.let { clipboard.setText(AnnotatedString(it)) }
+            },
+            onClickShareExport = viewModel::onClickShareExport,
+            onDismissExportQrSheet = viewModel::onDismissExportQrSheet,
+        )
+    }
 }
 
 @Composable
@@ -83,7 +143,19 @@ fun ScreenNode(
     onTogglePeers: () -> Unit = {},
     onToggleDiagnostics: () -> Unit = {},
     onDisconnectPeer: (String) -> Unit = {},
-    onPingPeers: () -> Unit = {}
+    onPingPeers: () -> Unit = {},
+    onClickScan: () -> Unit = {},
+    onClickPaste: () -> Unit = {},
+    onDismissScanSheet: () -> Unit = {},
+    onDismissPasteSheet: () -> Unit = {},
+    onAccumulatorReceived: (String) -> Unit = {},
+    onDismissImportConfirm: () -> Unit = {},
+    onConfirmImport: () -> Unit = {},
+    onToggleExportCard: () -> Unit = {},
+    onClickShowExportQr: () -> Unit = {},
+    onClickCopyExport: () -> Unit = {},
+    onClickShareExport: () -> Unit = {},
+    onDismissExportQrSheet: () -> Unit = {},
 ) {
     var peerToDisconnect by remember { mutableStateOf<String?>(null) }
     var showPingConfirmation by remember { mutableStateOf(false) }
@@ -130,6 +202,42 @@ fun ScreenNode(
         )
     }
 
+    if (uiState.ibd && uiState.isScanSheetOpen) {
+        UtreexoScanSheet(
+            onPayloadScanned = onAccumulatorReceived,
+            onDismiss = onDismissScanSheet,
+            onPasteFallback = {
+                onDismissScanSheet()
+                onClickPaste()
+            },
+        )
+    }
+    if (uiState.ibd && uiState.isPasteSheetOpen) {
+        UtreexoPasteSheet(
+            onPayloadSubmitted = onAccumulatorReceived,
+            onDismiss = onDismissPasteSheet,
+        )
+    }
+    val preview = uiState.pendingSnapshotPreview
+    if (uiState.ibd && preview != null) {
+        UtreexoImportConfirmDialog(
+            preview = preview,
+            onConfirm = onConfirmImport,
+            onDismiss = onDismissImportConfirm,
+        )
+    }
+    val exportForQr = uiState.exportPayload
+    if (!uiState.ibd && uiState.isExportQrSheetOpen && exportForQr != null) {
+        UtreexoExportQrSheet(
+            payload = exportForQr,
+            onDismiss = onDismissExportQrSheet,
+        )
+    }
+
+    if (uiState.isApplyingSnapshot) {
+        ApplyingSnapshotOverlay()
+    }
+
     LazyColumn(
         modifier = modifier
             .fillMaxSize()
@@ -148,265 +256,308 @@ fun ScreenNode(
                 textAlign = TextAlign.Center
             )
         }
-            if (uiState.ibd && uiState.utreexoPeerCount == 0) {
-                item { UtreexoWarningCard() }
-            }
-            // Sync Progress Card
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                    ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        if (uiState.ibd && uiState.utreexoPeerCount == 0) {
+            item { UtreexoWarningCard() }
+        }
+        // Sync Progress Card
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(20.dp)
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                stringResource(R.string.sync),
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                            if (uiState.ibd && uiState.syncDecimal == 0f) {
-                                Text(
-                                    stringResource(R.string.syncing_headers),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            } else {
-                                Text(
-                                    "${uiState.syncPercentage}%",
-                                    style = MaterialTheme.typography.headlineMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                        }
-
-                        Spacer(modifier = Modifier.height(12.dp))
-
-                        if (uiState.ibd && uiState.syncDecimal == 0f) {
-                            LinearProgressIndicator(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(8.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                                color = MaterialTheme.colorScheme.primary,
-                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            )
-                        } else {
-                            LinearProgressIndicator(
-                                progress = { uiState.syncDecimal },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(8.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                                color = MaterialTheme.colorScheme.primary,
-                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Network Info Card
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(20.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            "Network Information",
+                            stringResource(R.string.sync),
                             style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
-
-                        InfoRow(
-                            label = stringResource(R.string.network),
-                            value = uiState.network,
-                            icon = {
-                                Icon(
-                                    Icons.Outlined.Cloud,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                        )
-
-                        InfoRow(
-                            label = stringResource(R.string.number_of_peers),
-                            value = uiState.numberOfPeers,
-                            icon = {
-                                Icon(
-                                    Icons.Outlined.Person,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            },
-                            isLoading = uiState.numberOfPeers.isEmpty()
-                        )
-
-                        InfoRow(
-                            label = stringResource(R.string.difficulty),
-                            value = uiState.difficulty,
-                            icon = {
-                                Icon(
-                                    Icons.Outlined.Speed,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                        )
-                    }
-                }
-            }
-
-            // Peers Info Card
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
-                ) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        ExpandableHeader(
-                            title = "Peers (${uiState.numberOfPeers.ifEmpty { "0" }})",
-                            icon = Icons.Outlined.Hub,
-                            isExpanded = uiState.isPeersExpanded,
-                            onToggle = onTogglePeers
-                        )
-
-                        AnimatedVisibility(
-                            visible = uiState.isPeersExpanded,
-                            enter = expandVertically(),
-                            exit = shrinkVertically()
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 20.dp)
-                                    .padding(bottom = 20.dp),
-                                verticalArrangement = Arrangement.spacedBy(12.dp)
-                            ) {
-                                if (uiState.peers.isNotEmpty()) {
-                                    TextButton(onClick = { showPingConfirmation = true }) {
-                                        Icon(
-                                            Icons.Outlined.NetworkPing,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(16.dp)
-                                        )
-                                        Spacer(modifier = Modifier.width(4.dp))
-                                        Text("Ping All")
-                                    }
-                                }
-
-                                if (uiState.peers.isEmpty()) {
-                                    Text(
-                                        "No peers connected",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                } else {
-                                    uiState.peers.forEachIndexed { index, peer ->
-                                        PeerItem(
-                                            peer = peer,
-                                            onDisconnect = { peerToDisconnect = peer.address }
-                                        )
-                                        if (index < uiState.peers.lastIndex) {
-                                            HorizontalDivider(
-                                                color = MaterialTheme.colorScheme.outlineVariant
-                                            )
-                                        }
-                                    }
-                                }
-                            }
+                        if (uiState.ibd && uiState.syncDecimal == 0f) {
+                            Text(
+                                stringResource(R.string.syncing_headers),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        } else {
+                            Text(
+                                "${uiState.syncPercentage}%",
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
                         }
                     }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    if (uiState.ibd && uiState.syncDecimal == 0f) {
+                        LinearProgressIndicator(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(8.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                            color = MaterialTheme.colorScheme.primary,
+                            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                        )
+                    } else {
+                        LinearProgressIndicator(
+                            progress = { uiState.syncDecimal },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(8.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                            color = MaterialTheme.colorScheme.primary,
+                            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                        )
+                    }
                 }
             }
+        }
 
-            // Diagnostics Card
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        // Network Info Card
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        ExpandableHeader(
-                            title = stringResource(R.string.diagnostics),
-                            icon = Icons.Outlined.Info,
-                            isExpanded = uiState.isDiagnosticsExpanded,
-                            onToggle = onToggleDiagnostics
-                        )
+                    Text(
+                        "Network Information",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
 
-                        AnimatedVisibility(
-                            visible = uiState.isDiagnosticsExpanded,
-                            enter = expandVertically(),
-                            exit = shrinkVertically()
+                    InfoRow(
+                        label = stringResource(R.string.network),
+                        value = uiState.network,
+                        icon = {
+                            Icon(
+                                Icons.Outlined.Cloud,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    )
+
+                    InfoRow(
+                        label = stringResource(R.string.number_of_peers),
+                        value = uiState.numberOfPeers,
+                        icon = {
+                            Icon(
+                                Icons.Outlined.Person,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        isLoading = uiState.numberOfPeers.isEmpty()
+                    )
+
+                    InfoRow(
+                        label = stringResource(R.string.difficulty),
+                        value = uiState.difficulty,
+                        icon = {
+                            Icon(
+                                Icons.Outlined.Speed,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
+        if (uiState.ibd) {
+            item {
+                UtreexoImportCard(
+                    onScanClick = onClickScan,
+                    onPasteClick = onClickPaste,
+                )
+            }
+        }
+
+        // Peers Info Card
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    ExpandableHeader(
+                        title = "Peers (${uiState.numberOfPeers.ifEmpty { "0" }})",
+                        icon = Icons.Outlined.Hub,
+                        isExpanded = uiState.isPeersExpanded,
+                        onToggle = onTogglePeers
+                    )
+
+                    AnimatedVisibility(
+                        visible = uiState.isPeersExpanded,
+                        enter = expandVertically(),
+                        exit = shrinkVertically()
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                                .padding(bottom = 20.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 20.dp)
-                                    .padding(bottom = 20.dp),
-                                verticalArrangement = Arrangement.spacedBy(16.dp)
-                            ) {
-                                InfoRow(
-                                    label = stringResource(R.string.uptime),
-                                    value = uiState.uptime,
-                                    isLoading = uiState.uptime.isEmpty()
-                                )
+                            if (uiState.peers.isNotEmpty()) {
+                                TextButton(onClick = { showPingConfirmation = true }) {
+                                    Icon(
+                                        Icons.Outlined.NetworkPing,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text("Ping All")
+                                }
+                            }
 
-                                InfoRow(
-                                    label = stringResource(R.string.memory_used),
-                                    value = uiState.memoryUsed,
-                                    isLoading = uiState.memoryUsed.isEmpty()
+                            if (uiState.peers.isEmpty()) {
+                                Text(
+                                    "No peers connected",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
-
-                                InfoRow(
-                                    label = stringResource(R.string.memory_free),
-                                    value = uiState.memoryFree,
-                                    isLoading = uiState.memoryFree.isEmpty()
-                                )
-
-                                InfoRow(
-                                    label = stringResource(R.string.memory_total),
-                                    value = uiState.memoryTotal,
-                                    isLoading = uiState.memoryTotal.isEmpty()
-                                )
+                            } else {
+                                uiState.peers.forEachIndexed { index, peer ->
+                                    PeerItem(
+                                        peer = peer,
+                                        onDisconnect = { peerToDisconnect = peer.address }
+                                    )
+                                    if (index < uiState.peers.lastIndex) {
+                                        HorizontalDivider(
+                                            color = MaterialTheme.colorScheme.outlineVariant
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
         }
+
+        // Diagnostics Card
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    ExpandableHeader(
+                        title = stringResource(R.string.diagnostics),
+                        icon = Icons.Outlined.Info,
+                        isExpanded = uiState.isDiagnosticsExpanded,
+                        onToggle = onToggleDiagnostics
+                    )
+
+                    AnimatedVisibility(
+                        visible = uiState.isDiagnosticsExpanded,
+                        enter = expandVertically(),
+                        exit = shrinkVertically()
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                                .padding(bottom = 20.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            InfoRow(
+                                label = stringResource(R.string.uptime),
+                                value = uiState.uptime,
+                                isLoading = uiState.uptime.isEmpty()
+                            )
+
+                            InfoRow(
+                                label = stringResource(R.string.memory_used),
+                                value = uiState.memoryUsed,
+                                isLoading = uiState.memoryUsed.isEmpty()
+                            )
+
+                            InfoRow(
+                                label = stringResource(R.string.memory_free),
+                                value = uiState.memoryFree,
+                                isLoading = uiState.memoryFree.isEmpty()
+                            )
+
+                            InfoRow(
+                                label = stringResource(R.string.memory_total),
+                                value = uiState.memoryTotal,
+                                isLoading = uiState.memoryTotal.isEmpty()
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!uiState.ibd) {
+            item {
+                UtreexoExportCard(
+                    isExpanded = uiState.isExportCardExpanded,
+                    onToggle = onToggleExportCard,
+                    onShowQrClick = onClickShowExportQr,
+                    onCopyClick = onClickCopyExport,
+                    onShareClick = onClickShareExport,
+                )
+            }
+        }
     }
+}
+
+@Composable
+private fun ApplyingSnapshotOverlay() {
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.6f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            CircularProgressIndicator()
+            Text(
+                stringResource(R.string.utreexo_imported_restarting),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
 
 @Composable
 private fun UtreexoWarningCard() {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -122,6 +122,7 @@ fun ScreenNode(
             onAccumulatorReceived = viewModel::onAccumulatorReceived,
             onDismissImportConfirm = viewModel::onDismissImportConfirm,
             onConfirmImport = viewModel::onConfirmImport,
+            onToggleImportCard = viewModel::toggleImportCardExpanded,
             onToggleExportCard = viewModel::toggleExportCardExpanded,
             onClickShowExportQr = viewModel::onClickShowExportQr,
             onClickCopyExport = {
@@ -149,6 +150,7 @@ fun ScreenNode(
     onAccumulatorReceived: (String) -> Unit = {},
     onDismissImportConfirm: () -> Unit = {},
     onConfirmImport: () -> Unit = {},
+    onToggleImportCard: () -> Unit = {},
     onToggleExportCard: () -> Unit = {},
     onClickShowExportQr: () -> Unit = {},
     onClickCopyExport: () -> Unit = {},
@@ -391,6 +393,8 @@ fun ScreenNode(
         if (uiState.ibd) {
             item {
                 UtreexoImportCard(
+                    isExpanded = uiState.isImportCardExpanded,
+                    onToggle = onToggleImportCard,
                     onScanClick = onClickScan,
                     onPasteClick = onClickPaste,
                 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -160,6 +160,8 @@ fun ScreenNode(
     var peerToDisconnect by remember { mutableStateOf<String?>(null) }
     var showPingConfirmation by remember { mutableStateOf(false) }
 
+    val isHeaderSync = uiState.ibd && uiState.syncDecimal == 0f
+
     peerToDisconnect?.let { address ->
         AlertDialog(
             onDismissRequest = { peerToDisconnect = null },
@@ -283,7 +285,7 @@ fun ScreenNode(
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
-                        if (uiState.ibd && uiState.syncDecimal == 0f) {
+                        if (isHeaderSync) {
                             Text(
                                 stringResource(R.string.syncing_headers),
                                 style = MaterialTheme.typography.bodyMedium,
@@ -301,7 +303,7 @@ fun ScreenNode(
 
                     Spacer(modifier = Modifier.height(12.dp))
 
-                    if (uiState.ibd && uiState.syncDecimal == 0f) {
+                    if (isHeaderSync) {
                         LinearProgressIndicator(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -390,7 +392,7 @@ fun ScreenNode(
             }
         }
 
-        if (uiState.ibd) {
+        if (uiState.ibd && !isHeaderSync) {
             item {
                 UtreexoImportCard(
                     isExpanded = uiState.isImportCardExpanded,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -81,7 +80,6 @@ fun ScreenNode(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collect { event ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -463,6 +463,18 @@ fun ScreenNode(
             }
         }
 
+        if (!uiState.ibd) {
+            item {
+                UtreexoExportCard(
+                    isExpanded = uiState.isExportCardExpanded,
+                    onToggle = onToggleExportCard,
+                    onShowQrClick = onClickShowExportQr,
+                    onCopyClick = onClickCopyExport,
+                    onShareClick = onClickShareExport,
+                )
+            }
+        }
+
         // Diagnostics Card
         item {
             Card(
@@ -518,18 +530,6 @@ fun ScreenNode(
                         }
                     }
                 }
-            }
-        }
-
-        if (!uiState.ibd) {
-            item {
-                UtreexoExportCard(
-                    isExpanded = uiState.isExportCardExpanded,
-                    onToggle = onToggleExportCard,
-                    onShowQrClick = onClickShowExportQr,
-                    onCopyClick = onClickCopyExport,
-                    onShareClick = onClickShareExport,
-                )
             }
         }
     }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
@@ -23,14 +23,17 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 
 @Composable
 fun UtreexoExportCard(
@@ -114,6 +117,40 @@ fun UtreexoExportCard(
                     }
                 }
             }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoExportCardCollapsedPreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoExportCard(
+                isExpanded = false,
+                onToggle = {},
+                onShowQrClick = {},
+                onCopyClick = {},
+                onShareClick = {},
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoExportCardExpandedPreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoExportCard(
+                isExpanded = true,
+                onToggle = {},
+                onShowQrClick = {},
+                onCopyClick = {},
+                onShareClick = {},
+                modifier = Modifier.padding(16.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
@@ -1,0 +1,119 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.QrCode2
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+
+@Composable
+fun UtreexoExportCard(
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    onShowQrClick: () -> Unit,
+    onCopyClick: () -> Unit,
+    onShareClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onToggle)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    stringResource(R.string.utreexo_snapshot),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Icon(
+                    if (isExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        stringResource(R.string.utreexo_export_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        FilledTonalButton(
+                            onClick = onShowQrClick,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(Icons.Outlined.QrCode2, contentDescription = null)
+                            Text(text = " ${stringResource(R.string.utreexo_show_qr)}")
+                        }
+                        OutlinedButton(
+                            onClick = onCopyClick,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(Icons.Outlined.ContentCopy, contentDescription = null)
+                            Text(text = " ${stringResource(R.string.utreexo_copy)}")
+                        }
+                        OutlinedButton(
+                            onClick = onShareClick,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(Icons.Outlined.Share, contentDescription = null)
+                            Text(text = " ${stringResource(R.string.utreexo_share)}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
@@ -50,7 +50,7 @@ fun UtreexoExportCard(
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             ExpandableHeader(
-                title = stringResource(R.string.utreexo_snapshot),
+                title = stringResource(R.string.share_validation),
                 icon = Icons.Outlined.Backup,
                 isExpanded = isExpanded,
                 onToggle = onToggle,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
@@ -3,7 +3,6 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,9 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Backup
 import androidx.compose.material.icons.outlined.ContentCopy
-import androidx.compose.material.icons.outlined.ExpandLess
-import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.QrCode2
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Card
@@ -26,13 +24,12 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.components.ExpandableHeader
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 
 @Composable
@@ -47,31 +44,17 @@ fun UtreexoExportCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = onToggle)
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    stringResource(R.string.utreexo_snapshot),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Icon(
-                    if (isExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            ExpandableHeader(
+                title = stringResource(R.string.utreexo_snapshot),
+                icon = Icons.Outlined.Backup,
+                isExpanded = isExpanded,
+                onToggle = onToggle,
+            )
             AnimatedVisibility(
                 visible = isExpanded,
                 enter = expandVertically(),
@@ -80,7 +63,8 @@ fun UtreexoExportCard(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 20.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportCard.kt
@@ -89,17 +89,17 @@ fun UtreexoExportCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Spacer(Modifier.height(4.dp))
+                    FilledTonalButton(
+                        onClick = onShowQrClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Outlined.QrCode2, contentDescription = null)
+                        Text(text = " ${stringResource(R.string.utreexo_show_qr)}")
+                    }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        FilledTonalButton(
-                            onClick = onShowQrClick,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Icon(Icons.Outlined.QrCode2, contentDescription = null)
-                            Text(text = " ${stringResource(R.string.utreexo_show_qr)}")
-                        }
                         OutlinedButton(
                             onClick = onCopyClick,
                             modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportQrSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportQrSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -25,8 +26,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.encodeQr
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,59 +39,94 @@ fun UtreexoExportQrSheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val qr = remember(payload) { encodeQr(payload, size = QR_SIZE_PX) }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        UtreexoExportQrSheetContent(payload = payload, onDismiss = onDismiss)
+    }
+}
+
+@Composable
+private fun UtreexoExportQrSheetContent(
+    payload: String,
+    onDismiss: () -> Unit,
+) {
+    val qr = remember(payload) { encodeQr(payload, size = QR_SIZE_PX) }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            stringResource(R.string.utreexo_show_qr),
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+        if (qr != null) {
+            Box(
+                modifier = Modifier
+                    .size(QR_DISPLAY_DP.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.White),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    bitmap = qr,
+                    contentDescription = null,
+                    modifier = Modifier.size((QR_DISPLAY_DP - 16).dp),
+                )
+            }
             Text(
-                stringResource(R.string.utreexo_show_qr),
-                style = MaterialTheme.typography.titleLarge,
+                text = payload,
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                maxLines = 3,
             )
+        } else {
+            Text(
+                stringResource(R.string.utreexo_error_too_large_for_qr),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
 
-            if (qr != null) {
-                Box(
-                    modifier = Modifier
-                        .size(QR_DISPLAY_DP.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Color.White),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Image(
-                        bitmap = qr,
-                        contentDescription = null,
-                        modifier = Modifier.size((QR_DISPLAY_DP - 16).dp),
-                    )
-                }
-                Text(
-                    text = payload,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp),
-                    maxLines = 3,
-                )
-            } else {
-                Text(
-                    stringResource(R.string.utreexo_error_too_large_for_qr),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-
-            Spacer(Modifier.height(8.dp))
-            OutlinedButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
-                Text(stringResource(R.string.close))
-            }
+        Spacer(Modifier.height(8.dp))
+        OutlinedButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.close))
         }
     }
 }
 
 private const val QR_SIZE_PX = 768
 private const val QR_DISPLAY_DP = 280
+
+private const val SAMPLE_PAYLOAD = """{"version":1,"network":"bitcoin","block_hash":"000000000000000000009d36aae180d04aeac872adb14e22f65c8b6647a8bf79","height":939969,"leaves":2345678901,"roots":["08daaf0c6bc41531885cfcfdeb89c34bd4d06ab4b105cf0e81bd74ab082693f5","8d4166d0303d41f7023cd35b95b24455b99b2f4a2728083bba3d172727900bed"]}"""
+
+@PreviewLightDark
+@Composable
+private fun UtreexoExportQrSheetPreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoExportQrSheetContent(payload = SAMPLE_PAYLOAD, onDismiss = {})
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoExportQrSheetTooLargePreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoExportQrSheetContent(
+                payload = "X".repeat(OVERSIZE_PAYLOAD_LENGTH),
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+private const val OVERSIZE_PAYLOAD_LENGTH = 6000

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportQrSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoExportQrSheet.kt
@@ -1,0 +1,94 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.utils.encodeQr
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UtreexoExportQrSheet(
+    payload: String,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val qr = remember(payload) { encodeQr(payload, size = QR_SIZE_PX) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                stringResource(R.string.utreexo_show_qr),
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            if (qr != null) {
+                Box(
+                    modifier = Modifier
+                        .size(QR_DISPLAY_DP.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(Color.White),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        bitmap = qr,
+                        contentDescription = null,
+                        modifier = Modifier.size((QR_DISPLAY_DP - 16).dp),
+                    )
+                }
+                Text(
+                    text = payload,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                    maxLines = 3,
+                )
+            } else {
+                Text(
+                    stringResource(R.string.utreexo_error_too_large_for_qr),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.close))
+            }
+        }
+    }
+}
+
+private const val QR_SIZE_PX = 768
+private const val QR_DISPLAY_DP = 280

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
@@ -23,8 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Surface
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 
 @Composable
 fun UtreexoImportCard(
@@ -97,6 +100,20 @@ fun UtreexoImportCard(
                     )
                 }
             }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoImportCardPreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoImportCard(
+                onScanClick = {},
+                onPasteClick = {},
+                modifier = Modifier.padding(16.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
@@ -1,0 +1,102 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material.icons.outlined.ContentPaste
+import androidx.compose.material.icons.outlined.QrCodeScanner
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+
+@Composable
+fun UtreexoImportCard(
+    onScanClick: () -> Unit,
+    onPasteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Outlined.Bolt,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    stringResource(R.string.utreexo_import_cta_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Text(
+                stringResource(R.string.utreexo_import_cta_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilledTonalButton(
+                    onClick = onScanClick,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        Icons.Outlined.QrCodeScanner,
+                        contentDescription = null,
+                    )
+                    Spacer(Modifier.height(0.dp))
+                    Text(
+                        text = " ${stringResource(R.string.utreexo_scan_qr)}",
+                    )
+                }
+                OutlinedButton(
+                    onClick = onPasteClick,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        Icons.Outlined.ContentPaste,
+                        contentDescription = null,
+                    )
+                    Text(
+                        text = " ${stringResource(R.string.utreexo_paste_payload)}",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportCard.kt
@@ -1,5 +1,10 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,7 +12,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.QrCodeScanner
@@ -17,20 +24,24 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.compose.material3.Surface
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 
 @Composable
 fun UtreexoImportCard(
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
     onScanClick: () -> Unit,
     onPasteClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -42,74 +53,119 @@ fun UtreexoImportCard(
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Outlined.Bolt,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    stringResource(R.string.utreexo_import_cta_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-            Text(
-                stringResource(R.string.utreexo_import_cta_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
+        Column(modifier = Modifier.fillMaxWidth()) {
+            ImportCardHeader(
+                isExpanded = isExpanded,
+                onToggle = onToggle,
             )
-            Spacer(Modifier.height(4.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
             ) {
-                FilledTonalButton(
-                    onClick = onScanClick,
-                    modifier = Modifier.weight(1f),
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Icon(
-                        Icons.Outlined.QrCodeScanner,
-                        contentDescription = null,
-                    )
-                    Spacer(Modifier.height(0.dp))
                     Text(
-                        text = " ${stringResource(R.string.utreexo_scan_qr)}",
+                        stringResource(R.string.utreexo_import_cta_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
                     )
-                }
-                OutlinedButton(
-                    onClick = onPasteClick,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(
-                        Icons.Outlined.ContentPaste,
-                        contentDescription = null,
-                    )
-                    Text(
-                        text = " ${stringResource(R.string.utreexo_paste_payload)}",
-                    )
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        FilledTonalButton(
+                            onClick = onScanClick,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(Icons.Outlined.QrCodeScanner, contentDescription = null)
+                            Text(text = " ${stringResource(R.string.utreexo_scan_qr)}")
+                        }
+                        OutlinedButton(
+                            onClick = onPasteClick,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(Icons.Outlined.ContentPaste, contentDescription = null)
+                            Text(text = " ${stringResource(R.string.utreexo_paste_payload)}")
+                        }
+                    }
                 }
             }
         }
     }
 }
 
+@Composable
+private fun ImportCardHeader(
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    val rotation by animateFloatAsState(
+        targetValue = if (isExpanded) 180f else 0f,
+        label = "import_card_chevron",
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(vertical = 16.dp, horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Bolt,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        Text(
+            text = stringResource(R.string.utreexo_import_cta_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowDown,
+            contentDescription = if (isExpanded) "Collapse" else "Expand",
+            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier
+                .size(24.dp)
+                .rotate(rotation),
+        )
+    }
+}
+
 @PreviewLightDark
 @Composable
-private fun UtreexoImportCardPreview() {
+private fun UtreexoImportCardCollapsedPreview() {
     MandacaruTheme {
         Surface {
             UtreexoImportCard(
+                isExpanded = false,
+                onToggle = {},
+                onScanClick = {},
+                onPasteClick = {},
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoImportCardExpandedPreview() {
+    MandacaruTheme {
+        Surface {
+            UtreexoImportCard(
+                isExpanded = true,
+                onToggle = {},
                 onScanClick = {},
                 onPasteClick = {},
                 modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportConfirmDialog.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoImportConfirmDialog.kt
@@ -1,0 +1,104 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.domain.floresta.SnapshotPreview
+import java.text.NumberFormat
+
+@Composable
+fun UtreexoImportConfirmDialog(
+    preview: SnapshotPreview,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.utreexo_confirm_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                DialogRow(
+                    label = stringResource(R.string.utreexo_confirm_network),
+                    value = preview.network.name.lowercase()
+                        .replaceFirstChar { it.uppercase() },
+                )
+                DialogRow(
+                    label = stringResource(R.string.utreexo_confirm_height),
+                    value = NumberFormat.getNumberInstance().format(preview.height),
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        stringResource(R.string.utreexo_confirm_block_hash),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = preview.blockHash,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                clipboard.setText(AnnotatedString(preview.blockHash))
+                            },
+                    )
+                }
+                DialogRow(
+                    label = stringResource(R.string.utreexo_confirm_roots),
+                    value = preview.rootCount.toString(),
+                )
+                Text(
+                    stringResource(R.string.utreexo_confirm_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.utreexo_confirm_action_import))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun DialogRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoPasteSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoPasteSheet.kt
@@ -1,0 +1,80 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UtreexoPasteSheet(
+    onPayloadSubmitted: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var text by remember { mutableStateOf("") }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                stringResource(R.string.utreexo_paste_payload),
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                stringResource(R.string.utreexo_paste_hint),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                minLines = 4,
+                maxLines = 10,
+                placeholder = { Text("{\"version\":1, …}") },
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+                Button(
+                    onClick = { onPayloadSubmitted(text.trim()) },
+                    enabled = text.isNotBlank(),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.utreexo_confirm_action_import))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -147,6 +148,7 @@ private fun CameraPreview(
     )
 }
 
+@androidx.annotation.OptIn(ExperimentalGetImage::class)
 private fun processFrame(
     proxy: ImageProxy,
     scanner: BarcodeScanner,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,11 +33,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
@@ -190,4 +193,29 @@ private fun CameraDeniedFallback(onPasteFallback: () -> Unit) {
         }
     }
     Box(Modifier.fillMaxWidth())
+}
+
+@PreviewLightDark
+@Composable
+private fun UtreexoScanSheetPreview() {
+    MandacaruTheme {
+        Surface {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    stringResource(R.string.utreexo_scan_qr),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                CameraDeniedFallback(onPasteFallback = {})
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -1,0 +1,193 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import java.util.concurrent.Executors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UtreexoScanSheet(
+    onPayloadScanned: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onPasteFallback: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var hasCamera by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                stringResource(R.string.utreexo_scan_qr),
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            RequestCameraPermission(onPermissionChange = { hasCamera = it })
+
+            if (hasCamera) {
+                CameraPreview(
+                    onPayloadScanned = onPayloadScanned,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(360.dp),
+                )
+            } else {
+                CameraDeniedFallback(onPasteFallback = onPasteFallback)
+            }
+
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CameraPreview(
+    onPayloadScanned: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var alreadyFired by remember { mutableStateOf(false) }
+    val scanner = remember {
+        BarcodeScanning.getClient(
+            BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .build()
+        )
+    }
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            val previewView = PreviewView(ctx)
+            val providerFuture = ProcessCameraProvider.getInstance(ctx)
+            providerFuture.addListener({
+                val provider = providerFuture.get()
+                val preview = androidx.camera.core.Preview.Builder().build().also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+                val analysis = ImageAnalysis.Builder()
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .build()
+                    .also {
+                        it.setAnalyzer(analysisExecutor) { proxy ->
+                            processFrame(proxy, scanner) { payload ->
+                                if (!alreadyFired) {
+                                    alreadyFired = true
+                                    onPayloadScanned(payload)
+                                }
+                            }
+                        }
+                    }
+                try {
+                    provider.unbindAll()
+                    provider.bindToLifecycle(
+                        lifecycleOwner,
+                        CameraSelector.DEFAULT_BACK_CAMERA,
+                        preview,
+                        analysis,
+                    )
+                } catch (_: IllegalStateException) {
+                }
+            }, ContextCompat.getMainExecutor(ctx))
+            previewView
+        },
+    )
+}
+
+private fun processFrame(
+    proxy: ImageProxy,
+    scanner: BarcodeScanner,
+    onPayload: (String) -> Unit,
+) {
+    val mediaImage = proxy.image
+    if (mediaImage == null) {
+        proxy.close()
+        return
+    }
+    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
+    scanner.process(image)
+        .addOnSuccessListener { barcodes ->
+            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
+        }
+        .addOnCompleteListener { proxy.close() }
+}
+
+@Composable
+private fun CameraDeniedFallback(onPasteFallback: () -> Unit) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            stringResource(R.string.utreexo_scan_camera_denied),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Button(onClick = onPasteFallback) {
+            Text(stringResource(R.string.utreexo_paste_payload))
+        }
+        OutlinedButton(
+            onClick = {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+            },
+        ) {
+            Text(stringResource(R.string.open_app_settings))
+        }
+    }
+    Box(Modifier.fillMaxWidth())
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -20,8 +20,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -97,8 +100,9 @@ fun UtreexoScanSheet(
             }
 
             Spacer(Modifier.height(8.dp))
-            OutlinedButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
-                Text(stringResource(R.string.cancel))
+            OutlinedButton(onClick = onPasteFallback, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Outlined.ContentPaste, contentDescription = null)
+                Text(text = " ${stringResource(R.string.utreexo_paste_payload)}")
             }
         }
     }
@@ -231,7 +235,8 @@ private fun UtreexoScanSheetPreview() {
                 CameraDeniedFallback(onPasteFallback = {})
                 Spacer(Modifier.height(8.dp))
                 OutlinedButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
-                    Text(stringResource(R.string.cancel))
+                    Icon(Icons.Outlined.ContentPaste, contentDescription = null)
+                    Text(text = " ${stringResource(R.string.utreexo_paste_payload)}")
                 }
             }
         }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -13,10 +13,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -63,8 +66,10 @@ fun UtreexoScanSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .fillMaxHeight(SHEET_HEIGHT_FRACTION)
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 stringResource(R.string.utreexo_scan_qr),
@@ -74,12 +79,19 @@ fun UtreexoScanSheet(
             RequestCameraPermission(onPermissionChange = { hasCamera = it })
 
             if (hasCamera) {
-                CameraPreview(
-                    onPayloadScanned = onPayloadScanned,
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(360.dp),
-                )
+                        .weight(1f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CameraPreview(
+                        onPayloadScanned = onPayloadScanned,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(16.dp)),
+                    )
+                }
             } else {
                 CameraDeniedFallback(onPasteFallback = onPasteFallback)
             }
@@ -97,7 +109,6 @@ private fun CameraPreview(
     onPayloadScanned: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     var alreadyFired by remember { mutableStateOf(false) }
     val scanner = remember {
@@ -112,7 +123,9 @@ private fun CameraPreview(
     AndroidView(
         modifier = modifier,
         factory = { ctx ->
-            val previewView = PreviewView(ctx)
+            val previewView = PreviewView(ctx).apply {
+                scaleType = PreviewView.ScaleType.FILL_CENTER
+            }
             val providerFuture = ProcessCameraProvider.getInstance(ctx)
             providerFuture.addListener({
                 val provider = providerFuture.get()
@@ -197,6 +210,8 @@ private fun CameraDeniedFallback(onPasteFallback: () -> Unit) {
     Box(Modifier.fillMaxWidth())
 }
 
+private const val SHEET_HEIGHT_FRACTION = 0.9f
+
 @PreviewLightDark
 @Composable
 private fun UtreexoScanSheetPreview() {
@@ -206,7 +221,8 @@ private fun UtreexoScanSheetPreview() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
                     stringResource(R.string.utreexo_scan_qr),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/QrCodec.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/QrCodec.kt
@@ -1,0 +1,40 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.WriterException
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+import androidx.core.graphics.createBitmap
+
+/** Returns null when the payload does not fit in a single QR. */
+fun encodeQr(text: String, size: Int = 512): ImageBitmap? {
+    val hints = mapOf(
+        EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.L,
+        EncodeHintType.MARGIN to 1,
+    )
+    val matrix = try {
+        QRCodeWriter().encode(text, BarcodeFormat.QR_CODE, size, size, hints)
+    } catch (_: WriterException) {
+        return null
+    } catch (_: IllegalArgumentException) {
+        return null
+    }
+
+    val width = matrix.width
+    val height = matrix.height
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        val row = y * width
+        for (x in 0 until width) {
+            pixels[row + x] = if (matrix.get(x, y)) Color.BLACK else Color.WHITE
+        }
+    }
+    val bitmap = createBitmap(width, height)
+    bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+    return bitmap.asImageBitmap()
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/RequestCameraPermission.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/RequestCameraPermission.kt
@@ -1,0 +1,68 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+fun RequestCameraPermission(
+    showPermissionDialog: Boolean = true,
+    onPermissionChange: (Boolean) -> Unit,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnPermissionChange by rememberUpdatedState(onPermissionChange)
+
+    var isGranted by remember { mutableStateOf(isCameraGranted(context)) }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        isGranted = granted
+        currentOnPermissionChange(granted)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val current = isCameraGranted(context)
+                if (current != isGranted) {
+                    isGranted = current
+                    currentOnPermissionChange(current)
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    DisposableEffect(Unit) {
+        val current = isCameraGranted(context)
+        isGranted = current
+        currentOnPermissionChange(current)
+        if (!current && showPermissionDialog) {
+            launcher.launch(Manifest.permission.CAMERA)
+        }
+        onDispose { }
+    }
+}
+
+fun isCameraGranted(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/SnapshotCodec.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/SnapshotCodec.kt
@@ -1,0 +1,302 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Bech32m-based compact encoding for Utreexo snapshots.
+ *
+ * Canonical on-the-wire form is the Rust-side JSON emitted by
+ * `Florestad.dumpUtreexoState()`. This codec wraps that JSON into a smaller
+ * `UTREEXO1…` bech32m blob for QR / clipboard / share, and transparently
+ * unwraps on import so the FFI validator always receives JSON.
+ *
+ * See the plan file for the wire-format rationale.
+ */
+object SnapshotCodec {
+    private const val HRP = "utreexo"
+    private const val BECH32M_CONST: Int = 0x2bc830a3
+    private const val CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+    private const val FORMAT_VERSION: Byte = 1
+    private const val MIN_BODY_SIZE = 47 // up to and including root_count
+
+    fun isCompact(payload: String): Boolean =
+        payload.trim().lowercase().startsWith("${HRP}1")
+
+    fun encodeCompact(json: String): String {
+        val body = packBody(json)
+        val data5 = convertBits(body, 8, 5, pad = true)
+        return bech32mEncode(HRP, data5).uppercase()
+    }
+
+    fun normalizeToJson(payload: String): String {
+        val trimmed = payload.trim()
+        if (!isCompact(trimmed)) return trimmed
+        val (_, data5) = bech32mDecode(trimmed)
+        val body = convertBits5to8(data5)
+        return unpackBody(body)
+    }
+
+    // ---------------------------------------------------------------------
+    // Binary body <-> JSON
+    // ---------------------------------------------------------------------
+
+    private fun packBody(json: String): ByteArray {
+        val obj = JSONObject(json)
+        val network = obj.getString(KEY_NETWORK)
+        val networkByte = networkNameToByte(network)
+            ?: throw IllegalArgumentException("Unknown network: $network")
+        val height = obj.getLong(KEY_HEIGHT)
+        if (height !in 0L..UINT32_MAX) {
+            throw IllegalArgumentException("height out of u32 range: $height")
+        }
+        val leaves = obj.getLong(KEY_LEAVES)
+        if (leaves < 0L) {
+            throw IllegalArgumentException("leaves out of u64 range (negative Long): $leaves")
+        }
+        val blockHashHex = obj.getString(KEY_BLOCK_HASH)
+        val blockHashBytes = hexToBytes(blockHashHex)
+        require(blockHashBytes.size == 32) { "block_hash must be 32 bytes, got ${blockHashBytes.size}" }
+
+        val rootsJson = obj.getJSONArray(KEY_ROOTS)
+        require(rootsJson.length() in 0..MAX_ROOTS) {
+            "roots length ${rootsJson.length()} out of range [0,$MAX_ROOTS]"
+        }
+        val roots = Array(rootsJson.length()) { i ->
+            val rBytes = hexToBytes(rootsJson.getString(i))
+            require(rBytes.size == 32) { "root[$i] must be 32 bytes" }
+            rBytes
+        }
+
+        val buf = ByteBuffer
+            .allocate(MIN_BODY_SIZE + 32 * roots.size)
+            .order(ByteOrder.LITTLE_ENDIAN)
+        buf.put(FORMAT_VERSION)
+        buf.put(networkByte)
+        buf.putInt(height.toInt()) // u32 LE — mask happens via Int width
+        buf.putLong(leaves)
+        buf.put(blockHashBytes)
+        buf.put(roots.size.toByte())
+        roots.forEach { buf.put(it) }
+        return buf.array()
+    }
+
+    private fun unpackBody(body: ByteArray): String {
+        require(body.size >= MIN_BODY_SIZE) { "Compact body too short: ${body.size} < $MIN_BODY_SIZE" }
+        val buf = ByteBuffer.wrap(body).order(ByteOrder.LITTLE_ENDIAN)
+        val version = buf.get()
+        if (version != FORMAT_VERSION) {
+            throw IllegalArgumentException("Unsupported snapshot format version: $version")
+        }
+        val networkByte = buf.get()
+        val network = byteToNetworkName(networkByte)
+            ?: throw IllegalArgumentException("Unknown network tag byte: $networkByte")
+        val height = (buf.int.toLong() and 0xFFFF_FFFFL)
+        val leaves = buf.long
+        val blockHashBytes = ByteArray(32).also { buf.get(it) }
+        val rootCount = buf.get().toInt() and 0xFF
+        val remaining = body.size - MIN_BODY_SIZE
+        require(remaining == rootCount * 32) {
+            "root_count=$rootCount disagrees with remaining body bytes ($remaining)"
+        }
+        val roots = Array(rootCount) {
+            val r = ByteArray(32)
+            buf.get(r)
+            bytesToHex(r)
+        }
+
+        val rootsJson = org.json.JSONArray()
+        roots.forEach { rootsJson.put(it) }
+
+        return JSONObject().apply {
+            put(KEY_VERSION, version.toInt())
+            put(KEY_NETWORK, network)
+            put(KEY_BLOCK_HASH, bytesToHex(blockHashBytes))
+            put(KEY_HEIGHT, height)
+            put(KEY_LEAVES, leaves)
+            put(KEY_ROOTS, rootsJson)
+        }.toString()
+    }
+
+    private fun networkNameToByte(name: String): Byte? = when (name) {
+        "bitcoin" -> 0
+        "signet" -> 1
+        "testnet" -> 2
+        "testnet4" -> 3
+        "regtest" -> 4
+        else -> null
+    }
+
+    private fun byteToNetworkName(b: Byte): String? = when (b.toInt() and 0xFF) {
+        0 -> "bitcoin"
+        1 -> "signet"
+        2 -> "testnet"
+        3 -> "testnet4"
+        4 -> "regtest"
+        else -> null
+    }
+
+    // ---------------------------------------------------------------------
+    // bech32m
+    // ---------------------------------------------------------------------
+
+    private val CHARSET_REV: IntArray = IntArray(128) { -1 }.also { arr ->
+        CHARSET.forEachIndexed { i, c -> arr[c.code] = i }
+    }
+
+    private val GEN = intArrayOf(
+        0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+    )
+
+    private fun bech32mEncode(hrp: String, data5: IntArray): String {
+        val checksum = createChecksum(hrp, data5)
+        val sb = StringBuilder(hrp.length + 1 + data5.size + checksum.size)
+        sb.append(hrp).append('1')
+        data5.forEach { sb.append(CHARSET[it]) }
+        checksum.forEach { sb.append(CHARSET[it]) }
+        return sb.toString()
+    }
+
+    private fun bech32mDecode(s: String): Pair<String, IntArray> {
+        val upper = s.any { it.isUpperCase() }
+        val lower = s.any { it.isLowerCase() }
+        if (upper && lower) {
+            throw IllegalArgumentException("Mixed-case bech32 string")
+        }
+        val lowered = s.lowercase()
+        val sepPos = lowered.lastIndexOf('1')
+        require(sepPos >= 1) { "Missing HRP separator" }
+        val hrp = lowered.substring(0, sepPos)
+        val dataPart = lowered.substring(sepPos + 1)
+        require(hrp == HRP) { "Unexpected HRP: $hrp" }
+        require(dataPart.length >= 6) { "Data part too short for checksum" }
+        dataPart.forEach { c ->
+            val v = if (c.code < 128) CHARSET_REV[c.code] else -1
+            require(v >= 0) { "Invalid bech32 character: '$c'" }
+        }
+        val values = IntArray(dataPart.length) { CHARSET_REV[dataPart[it].code] }
+        require(verifyChecksum(hrp, values)) { "Bech32m checksum mismatch" }
+        return hrp to values.copyOfRange(0, values.size - 6)
+    }
+
+    private fun createChecksum(hrp: String, data: IntArray): IntArray {
+        val values = hrpExpand(hrp) + data + IntArray(6)
+        val polymod = polymod(values) xor BECH32M_CONST
+        return IntArray(6) { i ->
+            (polymod shr (5 * (5 - i))) and 31
+        }
+    }
+
+    private fun verifyChecksum(hrp: String, data: IntArray): Boolean =
+        polymod(hrpExpand(hrp) + data) == BECH32M_CONST
+
+    private fun hrpExpand(hrp: String): IntArray {
+        val out = IntArray(hrp.length * 2 + 1)
+        for (i in hrp.indices) out[i] = hrp[i].code shr 5
+        out[hrp.length] = 0
+        for (i in hrp.indices) out[hrp.length + 1 + i] = hrp[i].code and 31
+        return out
+    }
+
+    private fun polymod(values: IntArray): Int {
+        var chk = 1
+        for (v in values) {
+            val b = chk ushr 25
+            chk = ((chk and 0x1ffffff) shl 5) xor v
+            for (i in 0..4) {
+                if (((b ushr i) and 1) != 0) chk = chk xor GEN[i]
+            }
+        }
+        return chk
+    }
+
+    // ---------------------------------------------------------------------
+    // bit conversion
+    // ---------------------------------------------------------------------
+
+    private fun convertBits(data: ByteArray, fromBits: Int, toBits: Int, pad: Boolean): IntArray {
+        val ints = IntArray(data.size) { data[it].toInt() and 0xFF }
+        return convertBits(ints, fromBits, toBits, pad)
+    }
+
+    private fun convertBits(data: IntArray, fromBits: Int, toBits: Int, pad: Boolean): IntArray {
+        var acc = 0
+        var bits = 0
+        val out = ArrayList<Int>(data.size * fromBits / toBits + 1)
+        val maxv = (1 shl toBits) - 1
+        val maxAcc = (1 shl (fromBits + toBits - 1)) - 1
+        for (value in data) {
+            require(value >= 0 && (value ushr fromBits) == 0) { "value out of range in convertBits" }
+            acc = ((acc shl fromBits) or value) and maxAcc
+            bits += fromBits
+            while (bits >= toBits) {
+                bits -= toBits
+                out.add((acc ushr bits) and maxv)
+            }
+        }
+        if (pad) {
+            if (bits > 0) out.add((acc shl (toBits - bits)) and maxv)
+        } else {
+            require(bits < fromBits && ((acc shl (toBits - bits)) and maxv) == 0) {
+                "Non-zero padding in bit conversion"
+            }
+        }
+        return out.toIntArray()
+    }
+
+    // Overload: IntArray → ByteArray (for 5→8 bit round-trip)
+    private fun convertBits(data: IntArray, fromBits: Int, toBits: Int, pad: Boolean, asBytes: Boolean): ByteArray {
+        val ints = convertBits(data, fromBits, toBits, pad)
+        return ByteArray(ints.size) { ints[it].toByte() }
+    }
+
+    // Public alias used by unpackBody — 5→8 bit conversion that returns bytes.
+    // (Avoids overload ambiguity on the call site.)
+    private fun convertBits5to8(data: IntArray): ByteArray =
+        convertBits(data, 5, 8, pad = false, asBytes = true)
+
+    // ---------------------------------------------------------------------
+    // hex
+    // ---------------------------------------------------------------------
+
+    private fun hexToBytes(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Hex string has odd length" }
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = hexDigit(hex[i * 2])
+            val lo = hexDigit(hex[i * 2 + 1])
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private fun hexDigit(c: Char): Int = when (c) {
+        in '0'..'9' -> c - '0'
+        in 'a'..'f' -> 10 + (c - 'a')
+        in 'A'..'F' -> 10 + (c - 'A')
+        else -> throw IllegalArgumentException("Invalid hex digit: '$c'")
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xFF
+            sb.append(HEX_ALPHABET[v ushr 4])
+            sb.append(HEX_ALPHABET[v and 0x0F])
+        }
+        return sb.toString()
+    }
+
+    private const val HEX_ALPHABET = "0123456789abcdef"
+    private const val UINT32_MAX = 0xFFFF_FFFFL
+    private const val MAX_ROOTS = 63
+
+    private const val KEY_VERSION = "version"
+    private const val KEY_NETWORK = "network"
+    private const val KEY_BLOCK_HASH = "block_hash"
+    private const val KEY_HEIGHT = "height"
+    private const val KEY_LEAVES = "leaves"
+    private const val KEY_ROOTS = "roots"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,36 @@
     <string name="log_file_not_found">Log file not found</string>
     <string name="utreexo_warning_title">No Utreexo peers connected</string>
     <string name="utreexo_warning_message">The node cannot finish the initial block download without at least one peer advertising the Utreexo service flag. Attempting to connect to known bridges…</string>
+
+    <string name="cancel">Cancel</string>
+    <string name="close">Close</string>
+    <string name="open_app_settings">Open app settings</string>
+
+    <string name="utreexo_snapshot">Utreexo snapshot</string>
+    <string name="utreexo_snapshot_tagline">Transfer node state between devices to skip sync.</string>
+    <string name="utreexo_import_cta_title">Skip the wait</string>
+    <string name="utreexo_import_cta_body">Scan a Utreexo snapshot from a synced device to finish syncing instantly.</string>
+    <string name="utreexo_export_body">Share this node\'s state to let another device skip sync.</string>
+    <string name="utreexo_scan_qr">Scan QR</string>
+    <string name="utreexo_paste_payload">Paste</string>
+    <string name="utreexo_paste_hint">Paste the snapshot JSON produced by another synced Floresta node.</string>
+    <string name="utreexo_show_qr">Show QR</string>
+    <string name="utreexo_copy">Copy</string>
+    <string name="utreexo_share">Share</string>
+    <string name="utreexo_confirm_title">Import Utreexo snapshot?</string>
+    <string name="utreexo_confirm_network">Network</string>
+    <string name="utreexo_confirm_height">Height</string>
+    <string name="utreexo_confirm_block_hash">Block hash</string>
+    <string name="utreexo_confirm_roots">Roots</string>
+    <string name="utreexo_confirm_body">Existing sync progress will be replaced. Your wallet descriptors are preserved. The app will restart.</string>
+    <string name="utreexo_confirm_action_import">Import</string>
+    <string name="utreexo_copied">Copied to clipboard</string>
+    <string name="utreexo_imported_restarting">Applying snapshot…</string>
+    <string name="utreexo_error_wrong_network">This snapshot is for %1$s but your node is on %2$s.</string>
+    <string name="utreexo_error_invalid_json">Unrecognised snapshot format.</string>
+    <string name="utreexo_error_unsupported_version">This snapshot uses a newer format than this app supports.</string>
+    <string name="utreexo_error_invalid_hex">Snapshot contains malformed data.</string>
+    <string name="utreexo_error_not_synced">This node hasn\'t finished syncing yet.</string>
+    <string name="utreexo_error_too_large_for_qr">This snapshot is too large for a QR code. Use Copy or Share instead.</string>
+    <string name="utreexo_scan_camera_denied">Camera permission is required to scan a QR.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
     <string name="close">Close</string>
     <string name="open_app_settings">Open app settings</string>
 
-    <string name="utreexo_snapshot">Utreexo snapshot</string>
+    <string name="share_validation">Share validation</string>
     <string name="utreexo_snapshot_tagline">Transfer node state between devices to skip sync.</string>
     <string name="utreexo_import_cta_title">Skip the wait</string>
     <string name="utreexo_import_cta_body">Scan a Utreexo snapshot from a synced device to finish syncing instantly.</string>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/SnapshotCodecTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/SnapshotCodecTest.kt
@@ -1,0 +1,180 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SnapshotCodecTest {
+
+    private fun sampleJson(
+        network: String = "bitcoin",
+        height: Long = 939969L,
+        leaves: Long = 2_345_678_901L,
+        blockHash: String = "000000000000000000009d36aae180d04aeac872adb14e22f65c8b6647a8bf79",
+        roots: List<String> = listOf(
+            "08daaf0c6bc41531885cfcfdeb89c34bd4d06ab4b105cf0e81bd74ab082693f5",
+            "8d4166d0303d41f7023cd35b95b24455b99b2f4a2728083bba3d172727900bed",
+            "08d95bc9b7bc0bc07c9f626322c0092bd16c198fcb96d290fe1a191e9719b4c9",
+        ),
+    ): String = JSONObject().apply {
+        put("version", 1)
+        put("network", network)
+        put("block_hash", blockHash)
+        put("height", height)
+        put("leaves", leaves)
+        put("roots", JSONArray().apply { roots.forEach { put(it) } })
+    }.toString()
+
+    private fun assertJsonEquivalent(expected: String, actual: String) {
+        val a = JSONObject(expected)
+        val b = JSONObject(actual)
+        assertEquals(a.getInt("version"), b.getInt("version"))
+        assertEquals(a.getString("network"), b.getString("network"))
+        assertEquals(a.getString("block_hash"), b.getString("block_hash"))
+        assertEquals(a.getLong("height"), b.getLong("height"))
+        assertEquals(a.getLong("leaves"), b.getLong("leaves"))
+        val ar = a.getJSONArray("roots")
+        val br = b.getJSONArray("roots")
+        assertEquals(ar.length(), br.length())
+        for (i in 0 until ar.length()) {
+            assertEquals(ar.getString(i), br.getString(i))
+        }
+    }
+
+    @Test
+    fun `round-trip preserves every field for bitcoin`() {
+        val json = sampleJson()
+        val compact = SnapshotCodec.encodeCompact(json)
+        val back = SnapshotCodec.normalizeToJson(compact)
+        assertJsonEquivalent(json, back)
+    }
+
+    @Test
+    fun `round-trip preserves every field for signet`() {
+        val json = sampleJson(
+            network = "signet",
+            height = 200_000L,
+            leaves = 123_456L,
+            blockHash = "00000000aabbccddeeff00112233445566778899aabbccddeeff001122334455",
+            roots = listOf(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            ),
+        )
+        val compact = SnapshotCodec.encodeCompact(json)
+        val back = SnapshotCodec.normalizeToJson(compact)
+        assertJsonEquivalent(json, back)
+    }
+
+    @Test
+    fun `round-trip handles regtest with empty roots`() {
+        val json = sampleJson(
+            network = "regtest",
+            height = 0L,
+            leaves = 0L,
+            blockHash = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+            roots = emptyList(),
+        )
+        val compact = SnapshotCodec.encodeCompact(json)
+        val back = SnapshotCodec.normalizeToJson(compact)
+        assertJsonEquivalent(json, back)
+    }
+
+    @Test
+    fun `encodeCompact emits uppercase UTREEXO1 prefix`() {
+        val compact = SnapshotCodec.encodeCompact(sampleJson())
+        assertTrue(compact.startsWith("UTREEXO1"))
+        // Canonical: entire string is uppercase.
+        assertEquals(compact, compact.uppercase())
+    }
+
+    @Test
+    fun `size sanity — 21 roots fits well under 1200 chars`() {
+        val roots = (0 until 21).map { String.format("%064x", it.toLong()) }
+        val compact = SnapshotCodec.encodeCompact(sampleJson(roots = roots))
+        assertTrue("compact length ${compact.length}", compact.length <= 1200)
+    }
+
+    @Test
+    fun `legacy JSON passes through unchanged`() {
+        val json = sampleJson()
+        val normalized = SnapshotCodec.normalizeToJson(json)
+        assertEquals(json, normalized)
+    }
+
+    @Test
+    fun `decoder accepts lowercase canonical form`() {
+        val compact = SnapshotCodec.encodeCompact(sampleJson()).lowercase()
+        val back = SnapshotCodec.normalizeToJson(compact)
+        assertJsonEquivalent(sampleJson(), back)
+    }
+
+    @Test
+    fun `mixed case is rejected`() {
+        val compact = SnapshotCodec.encodeCompact(sampleJson())
+        val mixed = compact.substring(0, 8) + compact.substring(8).lowercase()
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            SnapshotCodec.normalizeToJson(mixed)
+        }
+        assertTrue(ex.message!!.contains("Mixed"))
+    }
+
+    @Test
+    fun `checksum mismatch is rejected`() {
+        val compact = SnapshotCodec.encodeCompact(sampleJson())
+        // Mutate a data char in the middle.
+        val mid = compact.length / 2
+        val mutated = buildString {
+            append(compact.substring(0, mid))
+            // Pick a different valid charset char.
+            val original = compact[mid]
+            val alt = if (original == 'Q') 'P' else 'Q'
+            append(alt)
+            append(compact.substring(mid + 1))
+        }
+        assertNotEquals(compact, mutated)
+        assertThrows(IllegalArgumentException::class.java) {
+            SnapshotCodec.normalizeToJson(mutated)
+        }
+    }
+
+    @Test
+    fun `non-utreexo HRP falls through as pass-through — not a codec error`() {
+        // Strings that don't start with `utreexo1` are treated as legacy JSON
+        // and returned unchanged. They'll fail later at the FFI validator.
+        val notUtreexo = "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4"
+        assertEquals(notUtreexo, SnapshotCodec.normalizeToJson(notUtreexo))
+    }
+
+    @Test
+    fun `UTREEXO prefix but malformed body throws`() {
+        // Starts with the expected HRP, so the codec attempts to decode —
+        // but the content is garbage, so it must fail fast rather than pass through.
+        val malformed = "UTREEXO1QQQQQQQQQQQQ"
+        assertThrows(IllegalArgumentException::class.java) {
+            SnapshotCodec.normalizeToJson(malformed)
+        }
+    }
+
+    @Test
+    fun `isCompact recognises prefix`() {
+        val compact = SnapshotCodec.encodeCompact(sampleJson())
+        assertTrue(SnapshotCodec.isCompact(compact))
+        assertTrue(SnapshotCodec.isCompact(compact.lowercase()))
+        assertTrue(SnapshotCodec.isCompact("  $compact  "))
+        assertFalse(SnapshotCodec.isCompact(sampleJson()))
+        assertFalse(SnapshotCodec.isCompact("bc1qabc"))
+    }
+
+    @Test
+    fun `unknown network name during encode is rejected`() {
+        val json = sampleJson(network = "mainnet-v2")
+        assertThrows(IllegalArgumentException::class.java) {
+            SnapshotCodec.encodeCompact(json)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,9 @@ jetbrainsKotlinJvm = "2.3.20"
 datastorePreferences = "1.2.1"
 detekt = "1.23.7"
 detektComposeRules = "0.4.22"
+zxing-core = "3.5.3"
+camerax = "1.3.4"
+mlkit-barcode = "17.3.0"
 
 [libraries]
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
@@ -50,6 +53,13 @@ koin-test = { module = "io.insert-koin:koin-test-junit4" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektComposeRules" }
+
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
+mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkit-barcode" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Lets users move a synced Floresta node's validation state between devices. A synced phone can export its Utreexo accumulator (QR / Copy / Share), and a fresh or still-syncing phone can scan / paste to skip most of IBD.
- Closes #29 (import) and #30 (export). Rides on the just-merged fork PRs [jvsena42/Floresta-mandacaru#7](https://github.com/jvsena42/Floresta-mandacaru/pull/7) and [jvsena42/floresta-mandacaru-ffi#12](https://github.com/jvsena42/floresta-mandacaru-ffi/pull/12), which expose the core \`dump_utreexo_state\` / \`Config.user_utreexo_snapshot_json\` surface through UniFFI.
- Upstream tracking: [getfloresta/Floresta#990](https://github.com/getfloresta/Floresta/issues/990).

## UX
- **Node screen only** (no Settings entry, per user's placement decision). Neither card is manually dismissable — visibility is driven entirely by \`NodeUiState.ibd\`:
  - \`ibd == true\` → **Utreexo snapshot** import card: *Scan QR* / *Paste* buttons. Hidden during the header-only phase (\`syncDecimal == 0f\`) so it doesn't compete with the initial progress indicator.
  - \`ibd == false\` → **Share validation** export card (collapsible, matches the Peers / Diagnostics card pattern): *Show QR* / *Copy* / *Share* buttons.
- **Import guard**: a confirmation dialog shows source network, block height, tappable-to-copy block hash, and root count before any destructive action. Wrong-network / malformed payloads are refused via the FFI's \`validateUtreexoSnapshotJson\` pre-flight with a network-mismatch snackbar so the dialog never opens for bad payloads.
- **Compact QR**: payloads go through a bech32m encoder (\`UTREEXO1…\`, uppercase, HRP \`utreexo\`) before rendering, so QR uses alphanumeric mode and the ~1.5 KB JSON shrinks to ~1.15 KB of QR-native chars — significantly less dense to scan.
- **Data hygiene**: chaindata + cfilters are **preserved** on import (the core's \`mark_chain_as_assumed\` overlays the accumulator on top of existing headers — header sync resumes from the previous tip instead of restarting from genesis). Wallet descriptors and the watch-only DB are never touched.

## Key files
- \`presentation/ui/screens/node/ScreenNode.kt\` — gates the cards on \`ibd\` / \`isHeaderSync\`, threads \`restartApplication\` from MainActivity, wires scan / paste / confirm / export sheets into the existing Node screen.
- \`presentation/ui/screens/node/UtreexoImportCard.kt\`, \`UtreexoExportCard.kt\` — expandable cards, hoisted \`isExpanded\` state.
- \`presentation/ui/screens/node/UtreexoScanSheet.kt\` — CameraX + ML Kit scanner in a tall bottom sheet, camera-denied fallback, paste escape hatch.
- \`presentation/ui/screens/node/UtreexoPasteSheet.kt\`, \`UtreexoExportQrSheet.kt\`, \`UtreexoImportConfirmDialog.kt\`.
- \`presentation/utils/QrCodec.kt\` — ZXing encoder, returns null if payload exceeds QR byte capacity (the bech32m compression keeps us comfortably inside the limit today).
- \`presentation/utils/SnapshotCodec.kt\` — hand-rolled bech32m with 5↔8 bit conversion, binary body packing (version / network / height / leaves / block_hash / roots), and a \`normalizeToJson\` auto-detection that falls through for legacy JSON payloads.
- \`presentation/utils/RequestCameraPermission.kt\` — mirrors the existing \`RequestNotificationPermissions\` pattern.
- \`domain/floresta/UtreexoSnapshotService.kt\` — thin wrapper around the UniFFI calls with a \`peek\` for the confirmation dialog.
- \`domain/floresta/FlorestaDaemon.kt\` + \`data/floresta/FlorestaDaemonImpl.kt\` — new \`dumpUtreexoState\` / \`prepareForSnapshotImport\` methods; \`start()\` reads the pending snapshot from DataStore and plugs it into \`Config.userUtreexoSnapshotJson\`, flipping \`assumeUtreexo = true\` whenever a pending snapshot is present.
- \`presentation/ui/screens/node/NodeViewModel.kt\` — snapshot-related actions, event flow for \`OnSnapshotApplied\` / \`OnShareAccumulator\`, clears the pending snapshot once \`ibd\` flips false.
- \`data/PreferenceKeys.kt\` — new \`PENDING_UTREEXO_SNAPSHOT\` key.
- \`AndroidManifest.xml\` — adds \`CAMERA\` permission (optional camera feature flag for tablets without a rear camera).
- \`gradle/libs.versions.toml\` + \`app/build.gradle.kts\` — adds \`zxing-core\`, CameraX (core / camera2 / lifecycle / view), \`mlkit-barcode\`, and \`org.json:json\` as a test dep so \`JSONObject\` isn't stubbed at unit-test time.
- New binding artefacts: \`jniLibs/arm64-v8a/libuniffi_floresta.so\` and \`com/florestad/florestad.kt\` (\`update-bindings.sh\` against the matching FFI fork).

## Test plan
- [x] \`./gradlew test\` — all unit suites pass, including 13 new \`SnapshotCodecTest\` cases (round-trip on all networks, size sanity, legacy JSON passthrough, case rules, checksum mutation, malformed body, unknown network).
- [x] \`./gradlew assembleDebug\` — APK builds.
- [x] \`./gradlew detekt\` — clean.
- [x] On-device end-to-end (mainnet): scan a bech32m \`UTREEXO1…\` payload → confirmation dialog shows expected height / block hash / root count → restart → debug.log reports \`applying user_utreexo_snapshot_json: height=946350 leaves=… roots=16 …\` and \`assume_utreexo precedence: user=Some(…) picked=Some(…)\` → header sync resumes from previous tip (not from height 1) and \`Assuming chain with height=946350 tip=…\` fires once peers go quiet.
- [x] On-device refusal paths: wrong network → red snackbar; truncated JSON → \"Unrecognised snapshot format\"; corrupted bech32m char → \"Snapshot contains malformed data\".
- [x] On-device export: post-IBD, Copy yields a \`UTREEXO1…\` string ≤ 1200 chars; Show QR renders a scannable code that a second device can import cleanly.

## Follow-ups
- Upstream enhancement tracked at [getfloresta/Floresta#990](https://github.com/getfloresta/Floresta/issues/990).
- Settings re-entry is intentionally out of scope per the placement decision; can be added later without reshaping the architecture if adoption data argues for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)