### PR TITLE
feat: advertise custom user agent in P2P version handshake

### DIFF
--- a/app/src/main/java/com/florestad/florestad.kt
+++ b/app/src/main/java/com/florestad/florestad.kt
@@ -1058,6 +1058,7 @@ data class Config (
     var `walletDescriptor`: String? = null, 
     var `filtersStartHeight`: Int? = null, 
     var `assumeUtreexo`: Boolean = false, 
+    var `userAgent`: String? = null, 
     var `userUtreexoSnapshotJson`: String? = null
 ) {
     
@@ -1076,6 +1077,7 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalInt.read(buf),
             FfiConverterBoolean.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -1088,6 +1090,7 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalString.allocationSize(value.`walletDescriptor`) +
             FfiConverterOptionalInt.allocationSize(value.`filtersStartHeight`) +
             FfiConverterBoolean.allocationSize(value.`assumeUtreexo`) +
+            FfiConverterOptionalString.allocationSize(value.`userAgent`) +
             FfiConverterOptionalString.allocationSize(value.`userUtreexoSnapshotJson`)
     )
 
@@ -1100,6 +1103,7 @@ public object FfiConverterTypeConfig: FfiConverterRustBuffer<Config> {
             FfiConverterOptionalString.write(value.`walletDescriptor`, buf)
             FfiConverterOptionalInt.write(value.`filtersStartHeight`, buf)
             FfiConverterBoolean.write(value.`assumeUtreexo`, buf)
+            FfiConverterOptionalString.write(value.`userAgent`, buf)
             FfiConverterOptionalString.write(value.`userUtreexoSnapshotJson`, buf)
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -40,14 +40,14 @@ class FlorestaDaemonImpl(
                     ?: WalletBirthday.defaultYear()
                 WalletBirthday.bitcoinHeightForYear(year)
             } else null
+            val userAgent =
+                "/Floresta:${Constants.FLORESTA_VERSION}/mandacaru:${BuildConfig.VERSION_NAME}/"
             Log.i(
                 TAG,
                 "start: pendingSnapshot=${pendingSnapshot?.length ?: 0} chars, " +
                     "network=$network, datadir=$datadir, " +
-                    "filtersStartHeight=$filtersStartHeight",
+                    "filtersStartHeight=$filtersStartHeight, userAgent=$userAgent",
             )
-            val userAgent =
-                "/Floresta:${Constants.FLORESTA_VERSION}/mandacaru:${BuildConfig.VERSION_NAME}/"
             val config = Config(
                 dataDir = datadir,
                 network = network,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -3,9 +3,11 @@ package com.github.jvsena42.mandacaru.data.floresta
 import android.util.Log
 import com.florestad.Config
 import com.florestad.Florestad
+import com.github.jvsena42.mandacaru.BuildConfig
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
+import com.github.jvsena42.mandacaru.domain.model.Constants
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -44,12 +46,15 @@ class FlorestaDaemonImpl(
                     "network=$network, datadir=$datadir, " +
                     "filtersStartHeight=$filtersStartHeight",
             )
+            val userAgent =
+                "/Floresta:${Constants.FLORESTA_VERSION}/mandacaru:${BuildConfig.VERSION_NAME}/"
             val config = Config(
                 dataDir = datadir,
                 network = network,
                 assumeUtreexo = true,
                 userUtreexoSnapshotJson = pendingSnapshot,
                 filtersStartHeight = filtersStartHeight,
+                userAgent = userAgent,
             )
             daemon = Florestad.fromConfig(config)
             daemon?.start()?.also {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/Constants.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/Constants.kt
@@ -1,6 +1,7 @@
 package com.github.jvsena42.mandacaru.domain.model
 
 object Constants {
+    const val FLORESTA_VERSION = "0.9.1"
     const val ELECTRUM_ADDRESS = "127.0.0.1:50001"
     const val RPC_PORT_MAINNET = "8332"
     const val RPC_PORT_TESTNET = "18332"


### PR DESCRIPTION
## Summary
- Construct `/Floresta:${FLORESTA_VERSION}/mandacaru:${BuildConfig.VERSION_NAME}/` and pass it through the regenerated `Config.userAgent` so the on-device daemon advertises a recognizable UA on the wire.
- Add `Constants.FLORESTA_VERSION = "0.9.1"` (kept in sync with the bundled `floresta-node` version when bindings are regenerated).
- Bundle regenerated `florestad.kt` + `libuniffi_floresta.so` built against a `floresta-mandacaru-ffi` branch that exposes the new `user_agent` field on `Config`.

## Dependency
The bundled native lib was built against a `floresta-mandacaru-ffi` branch that adds `user_agent` to the UDL `Config` dictionary. Upstream tracking issue: getfloresta/floresta-ffi#8. Once that lands, the FFI fork can rebase and we just regenerate bindings.

## Test plan
- [x] `./gradlew compileDebugKotlin` — green
- [x] `./gradlew installDebug` on an ARM64 device, launch app, confirm via `adb logcat -s FlorestaDaemonImpl:I`:
  ```
  userAgent=/Floresta:0.9.1/mandacaru:0.6.1/
  ```
- [ ] End-to-end peer verification: connect to a Bitcoin node you control and confirm `subver` in `getpeerinfo` matches the string above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)