### PR TITLE
fix: hide Share validation card until sync actually reaches tip

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -469,7 +469,7 @@ fun ScreenNode(
             }
         }
 
-        if (!uiState.ibd && uiState.utreexoPeerCount > 0) {
+        if (!uiState.ibd && uiState.syncDecimal >= 1f && uiState.utreexoPeerCount > 0) {
             item {
                 UtreexoExportCard(
                     isExpanded = uiState.isExportCardExpanded,


### PR DESCRIPTION
## Summary

- The export "Share validation" card was gated only on `!uiState.ibd`, but the daemon flips `ibd` to `false` once it crosses the assume-utreexo checkpoint — long before local validation reaches the actual chain tip.
- On Bitcoin mainnet today the card showed up while the sync gauge still read 99,25 % (live: `validated=940297`, `height=947439`, `progress=0.992462`, `ibd=false`).
- Fix: also require `uiState.syncDecimal >= 1f` before showing the card, so it only appears when validation has actually reached tip.

The deeper bug (daemon flipping `ibd` early) is being addressed in `Floresta-mandacaru#fix/ibd-flag-requires-full-validation`; this UI guard is correct regardless and protects users running older daemons.

## Test plan

- [ ] Mainnet device at <100 % sync — card stays hidden.
- [ ] Mainnet device fully synced with at least one utreexo peer — card appears.
- [ ] Signet/regtest still behaves the same when fully synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)