### PR TITLE
fix: reduce SurfaceFlinger / recomposition cost on Node screen

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -96,12 +96,10 @@ class NodeViewModel(
         val days = seconds / SECONDS_PER_DAY
         val hours = (seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR
         val minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
-        val secs = seconds % SECONDS_PER_MINUTE
         return buildString {
             if (days > 0) append("${days}d ")
             if (hours > 0 || days > 0) append("${hours}h ")
-            if (minutes > 0 || hours > 0 || days > 0) append("${minutes}m ")
-            append("${secs}s")
+            append("${minutes}m")
         }
     }
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -267,95 +267,15 @@ fun ScreenNode(
         if (uiState.ibd && uiState.utreexoPeerCount == 0) {
             item { UtreexoWarningCard() }
         }
-        // Sync Progress Card
         item {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(20.dp)
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            stringResource(syncTitleRes),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                        when {
-                            isHeaderSync && headerSyncDecimal != null -> {
-                                Text(
-                                    "${uiState.headerSyncPercentage}%",
-                                    style = MaterialTheme.typography.headlineMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                            isHeaderSync -> {
-                                Text(
-                                    stringResource(R.string.syncing_headers),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                            else -> {
-                                Text(
-                                    "${uiState.syncPercentage}%",
-                                    style = MaterialTheme.typography.headlineMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    when {
-                        isHeaderSync && headerSyncDecimal != null -> {
-                            LinearProgressIndicator(
-                                progress = { headerSyncDecimal },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(8.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                                color = MaterialTheme.colorScheme.primary,
-                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            )
-                        }
-                        isHeaderSync -> {
-                            LinearProgressIndicator(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(8.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                                color = MaterialTheme.colorScheme.primary,
-                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            )
-                        }
-                        else -> {
-                            LinearProgressIndicator(
-                                progress = { uiState.syncDecimal },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(8.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                                color = MaterialTheme.colorScheme.primary,
-                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
+            SyncProgressCard(
+                titleRes = syncTitleRes,
+                isHeaderSync = isHeaderSync,
+                headerSyncDecimal = headerSyncDecimal,
+                headerSyncPercentage = uiState.headerSyncPercentage,
+                syncPercentage = uiState.syncPercentage,
+                syncDecimal = uiState.syncDecimal,
+            )
         }
 
         // Network Info Card
@@ -404,7 +324,6 @@ fun ScreenNode(
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         },
-                        isLoading = uiState.numberOfPeers.isEmpty()
                     )
 
                     InfoRow(
@@ -544,10 +463,107 @@ fun ScreenNode(
                             InfoRow(
                                 label = stringResource(R.string.uptime),
                                 value = uiState.uptime,
-                                isLoading = uiState.uptime.isEmpty()
                             )
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SyncProgressCard(
+    titleRes: Int,
+    isHeaderSync: Boolean,
+    headerSyncDecimal: Float?,
+    headerSyncPercentage: String,
+    syncPercentage: String,
+    syncDecimal: Float,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(titleRes),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                when {
+                    isHeaderSync && headerSyncDecimal != null -> {
+                        Text(
+                            "$headerSyncPercentage%",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                    isHeaderSync -> {
+                        Text(
+                            stringResource(R.string.syncing_headers),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                    else -> {
+                        Text(
+                            "$syncPercentage%",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            when {
+                isHeaderSync && headerSyncDecimal != null -> {
+                    LinearProgressIndicator(
+                        progress = { headerSyncDecimal },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
+                }
+                isHeaderSync -> {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
+                }
+                else -> {
+                    LinearProgressIndicator(
+                        progress = { syncDecimal },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
                 }
             }
         }
@@ -704,7 +720,6 @@ private fun InfoRow(
     value: String,
     modifier: Modifier = Modifier,
     icon: @Composable (() -> Unit)? = null,
-    isLoading: Boolean = false,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -724,18 +739,12 @@ private fun InfoRow(
             )
         }
 
-        if (isLoading) {
-            LinearProgressIndicator(
-                modifier = Modifier.width(60.dp)
-            )
-        } else {
-            Text(
-                value,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        }
+        Text(
+            value.ifEmpty { "—" },
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Close #62 

Addresses high SurfaceFlinger usage on the Node screen reported on a tablet (issue #62).

- **Round `formatUptime` to minute precision** in `NodeViewModel`. With seconds precision the diagnostics row was emitting a new uptime string every 10s poll forever; at minute precision ~5/6 polls produce identical strings and `StateFlow`'s equality dedup suppresses the emit.
- **Extract `SyncProgressCard`** in `ScreenNode.kt` as a separate composable taking only stable, sync-related parameters (`titleRes`, `isHeaderSync`, `headerSyncDecimal`, `headerSyncPercentage`, `syncPercentage`, `syncDecimal`). With strong skipping (default in Kotlin 2.3.20 + `kotlin-compose` plugin), it now skips recomposition when only unrelated `NodeUiState` fields (uptime, peers list, dialog flags) change.
- **Replace `InfoRow`'s indeterminate `LinearProgressIndicator`** with `value.ifEmpty { "—" }`. Drops the `isLoading` param and updates both call sites (`numberOfPeers`, `uptime`). Removes a 60fps continuous frame producer that briefly ran on first paint.

Out of scope: indeterminate header-sync bar (only briefly visible during the IBD → first peer height window), `ApplyingSnapshotOverlay` spinner (short-lived, ends in restart), Blockchain search bar (user-triggered affordance).

## Test plan

- [ ] `./gradlew assembleDebug` — passes (verified locally)
- [ ] `./gradlew test` — passes (verified locally)
- [ ] On a tablet during IBD: open Layout Inspector with "Recomposition counts" enabled, sit on the Node screen for one minute. Diagnostics-uptime row should increment only on minute boundaries; the Sync Progress card should not increment when only uptime changes.
- [ ] Profile GPU Rendering (Developer Options) — bars should idle in steady state on the Node screen, with bumps only on real state movement.
- [ ] `adb shell dumpsys SurfaceFlinger --latency-clear` then `... --latency com.github.jvsena42.mandacaru/...MainActivity` after 30s idle on Node screen — frame count should be substantially lower than before.
- [ ] Visual: Diagnostics expanded shows `0m`, then `1m` after a minute (no seconds). Peers row shows `—` for a fraction of a second on first launch, then the count. Sync card behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)