### PR TITLE
fix: stop reporting "Fully synced" when daemon is stuck behind chain tip (#63)

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/HeaderSyncProgress.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/HeaderSyncProgress.kt
@@ -3,6 +3,8 @@ package com.github.jvsena42.mandacaru.domain.floresta
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 import kotlin.math.roundToInt
 
+private const val STALL_TOLERANCE_BLOCKS = 12
+
 fun computeHeaderSyncProgress(
     ourHeight: Int,
     peers: List<PeerInfoResult>,
@@ -11,4 +13,26 @@ fun computeHeaderSyncProgress(
     if (tip <= 0 || ourHeight <= 0) return null
     val ratio = (ourHeight.toFloat() / tip.toFloat()).coerceIn(0f, 1f)
     return (ratio * 10000f).roundToInt() / 10000f
+}
+
+/**
+ * Returns true when the daemon's `getblockchaininfo` claims sync is complete
+ * (`progress >= 1f`, `!ibd`) but our local height is meaningfully behind what
+ * peers report as their initial height — i.e. the chain is jammed early, not
+ * actually at the tip.
+ *
+ * Floresta computes `progress` as `validated / height`, so when both numbers
+ * stall together (e.g. `flat_chain_store` `IndexIsFull` on flaky storage), the
+ * daemon reports 100% even though headers never reached the tip.
+ */
+fun isLikelyStalled(
+    progress: Float,
+    ibd: Boolean,
+    ourHeight: Int,
+    peers: List<PeerInfoResult>,
+): Boolean {
+    if (ibd || progress < 1f) return false
+    val peerTip = peers.maxOfOrNull { it.initialHeight } ?: return false
+    if (peerTip <= 0 || ourHeight <= 0) return false
+    return ourHeight + STALL_TOLERANCE_BLOCKS < peerTip
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
@@ -17,6 +17,7 @@ import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
+import com.github.jvsena42.mandacaru.domain.floresta.isLikelyStalled
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 import com.github.jvsena42.mandacaru.presentation.ui.screens.main.MainActivity
 import com.github.jvsena42.mandacaru.presentation.utils.toSyncPercentageString
@@ -177,7 +178,17 @@ class FlorestaService : Service() {
                             } else {
                                 launch { utreexoBridgeAutoConnect.ensureUtreexoPeers() }
                             }
-                            maybeTriggerWalletRescan(data.result.progress, data.result.ibd)
+                            val stalled = isLikelyStalled(
+                                progress = data.result.progress,
+                                ibd = data.result.ibd,
+                                ourHeight = data.result.height,
+                                peers = peers,
+                            )
+                            maybeTriggerWalletRescan(
+                                progress = data.result.progress,
+                                ibd = data.result.ibd,
+                                stalled = stalled,
+                            )
                         }
                     }
                 } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -194,8 +205,8 @@ class FlorestaService : Service() {
      * chain looks fully synced (with a grace window so filter downloads can
      * catch up too), then clear the flag.
      */
-    private fun maybeTriggerWalletRescan(progress: Float, ibd: Boolean) {
-        if (ibd || progress < FULL_SYNC_THRESHOLD) {
+    private fun maybeTriggerWalletRescan(progress: Float, ibd: Boolean, stalled: Boolean) {
+        if (ibd || progress < FULL_SYNC_THRESHOLD || stalled) {
             fullySyncedSinceMs = null
             return
         }
@@ -266,6 +277,12 @@ class FlorestaService : Service() {
         } else {
             null
         }
+        val stalled = isLikelyStalled(
+            progress = progress,
+            ibd = ibd,
+            ourHeight = height,
+            peers = peers,
+        )
 
         when {
             headerDecimal != null -> {
@@ -281,6 +298,13 @@ class FlorestaService : Service() {
                 builder.setContentText("Syncing headers…")
                     .setSubText("Connecting to peers")
                     .setProgress(0, 0, true)
+                    .setColor(COLOR_PRIMARY.toColorInt())
+                    .setColorized(true)
+            }
+            stalled -> {
+                val formattedHeight = NumberFormat.getNumberInstance().format(height)
+                builder.setContentText("Sync stalled at block #$formattedHeight")
+                    .setSubText("Storage may be unhealthy")
                     .setColor(COLOR_PRIMARY.toColorInt())
                     .setColorized(true)
             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -16,6 +16,7 @@ data class NodeUiState(
     val headerHeightRaw: Int = 0,
     val headerSyncDecimal: Float? = null,
     val headerSyncPercentage: String = "0.00",
+    val isStalled: Boolean = false,
     val ibd: Boolean = false,
     val validatedBLocks: Int = 0,
     val peers: List<PeerInfoResult> = emptyList(),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -12,6 +12,7 @@ import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
 import com.github.jvsena42.mandacaru.domain.floresta.hasUtreexoServiceFlag
+import com.github.jvsena42.mandacaru.domain.floresta.isLikelyStalled
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
 import com.github.jvsena42.mandacaru.presentation.utils.SnapshotCodec
@@ -133,12 +134,19 @@ class NodeViewModel(
                     } else {
                         null
                     }
+                    val stalled = isLikelyStalled(
+                        progress = current.syncDecimal,
+                        ibd = current.ibd,
+                        ourHeight = current.headerHeightRaw,
+                        peers = peers,
+                    )
                     current.copy(
                         numberOfPeers = peers.size.toString(),
                         peers = peers,
                         utreexoPeerCount = peers.count { p -> p.services.hasUtreexoServiceFlag() },
                         headerSyncDecimal = decimal,
                         headerSyncPercentage = decimal?.toSyncPercentageString() ?: "0.00",
+                        isStalled = stalled,
                     )
                 }
             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -161,9 +161,11 @@ fun ScreenNode(
     var showPingConfirmation by remember { mutableStateOf(false) }
 
     val isHeaderSync = uiState.ibd && uiState.syncDecimal == 0f
+    val isStalled = uiState.isStalled
     val headerSyncDecimal = uiState.headerSyncDecimal
     val syncTitleRes = when {
         isHeaderSync -> R.string.syncing_headers_title
+        isStalled -> R.string.sync_stalled_title
         uiState.ibd -> R.string.syncing_blocks_title
         else -> R.string.sync
     }
@@ -267,10 +269,14 @@ fun ScreenNode(
         if (uiState.ibd && uiState.utreexoPeerCount == 0) {
             item { UtreexoWarningCard() }
         }
+        if (isStalled) {
+            item { SyncStalledWarningCard() }
+        }
         item {
             SyncProgressCard(
                 titleRes = syncTitleRes,
                 isHeaderSync = isHeaderSync,
+                isStalled = isStalled,
                 headerSyncDecimal = headerSyncDecimal,
                 headerSyncPercentage = uiState.headerSyncPercentage,
                 syncPercentage = uiState.syncPercentage,
@@ -476,6 +482,7 @@ fun ScreenNode(
 private fun SyncProgressCard(
     titleRes: Int,
     isHeaderSync: Boolean,
+    isStalled: Boolean,
     headerSyncDecimal: Float?,
     headerSyncPercentage: String,
     syncPercentage: String,
@@ -504,6 +511,7 @@ private fun SyncProgressCard(
                     color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
                 when {
+                    isStalled -> Unit
                     isHeaderSync && headerSyncDecimal != null -> {
                         Text(
                             "$headerSyncPercentage%",
@@ -533,6 +541,17 @@ private fun SyncProgressCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             when {
+                isStalled -> {
+                    LinearProgressIndicator(
+                        progress = { 0f },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                        color = MaterialTheme.colorScheme.error,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
+                }
                 isHeaderSync && headerSyncDecimal != null -> {
                     LinearProgressIndicator(
                         progress = { headerSyncDecimal },
@@ -565,6 +584,45 @@ private fun SyncProgressCard(
                         trackColor = MaterialTheme.colorScheme.surfaceVariant,
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SyncStalledWarningCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                Icons.Outlined.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    stringResource(R.string.sync_stalled_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+                Text(
+                    stringResource(R.string.sync_stalled_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
             }
         }
     }
@@ -784,6 +842,41 @@ private fun Preview() {
                             state = "Ready",
                             userAgent = "/Satoshi:28.1.0/"
                         )
+                    )
+                )
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun StalledPreview() {
+    MandacaruTheme {
+        Surface {
+            ScreenNode(
+                NodeUiState(
+                    numberOfPeers = "10",
+                    blockHeight = "17,904",
+                    headerHeightRaw = 17_904,
+                    blockHash = "0000000000000ed5f3f1d61f1bbf73c89c2cc01dec02e2fa7eaa9f6cabf2a7df",
+                    network = "BITCOIN",
+                    difficulty = "1.00",
+                    syncPercentage = "100.00",
+                    syncDecimal = 1f,
+                    ibd = false,
+                    isStalled = true,
+                    utreexoPeerCount = 1,
+                    uptime = "14h 02m",
+                    peers = listOf(
+                        PeerInfoResult(
+                            address = "194.145.199.26:8333",
+                            initialHeight = 947_390,
+                            kind = "regular",
+                            services = "ServiceFlags(NETWORK|WITNESS|COMPACT_FILTERS|UTREEXO)",
+                            state = "Ready",
+                            userAgent = "/Satoshi:30.0.0/"
+                        ),
                     )
                 )
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="syncing_headers">Syncing headers…</string>
     <string name="syncing_headers_title">Syncing headers</string>
     <string name="syncing_blocks_title">Syncing blocks</string>
+    <string name="sync_stalled_title">Sync stalled</string>
+    <string name="sync_stalled_message">The node is stuck far behind the chain tip. This usually means a storage problem. Reinstall Mandacaru on internal storage.</string>
     <string name="receive_bitcoin">Receive Bitcoin</string>
     <string name="your_bitcoin_infrastructure_in_a_single_app">Your bitcoin infrastructure in a single app</string>
     <string name="create_a_new_wallet">Create a new wallet</string>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/IsLikelyStalledTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/IsLikelyStalledTest.kt
@@ -1,0 +1,129 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IsLikelyStalledTest {
+
+    private fun peer(initialHeight: Int) = PeerInfoResult(
+        address = "1.2.3.4:8333",
+        initialHeight = initialHeight,
+        kind = "regular",
+        services = "ServiceFlags(NETWORK|WITNESS|UTREEXO)",
+        state = "Ready",
+        userAgent = "/Satoshi:30.0.0/",
+    )
+
+    @Test
+    fun `flags issue 63 scenario - daemon claims 100 percent at block 17904 while peers report tip near 947k`() {
+        assertTrue(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 17_904,
+                peers = listOf(peer(947_390), peer(947_391)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when daemon is still in IBD`() {
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = true,
+                ourHeight = 17_904,
+                peers = listOf(peer(947_390)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when progress is below 100 percent`() {
+        assertFalse(
+            isLikelyStalled(
+                progress = 0.99f,
+                ibd = false,
+                ourHeight = 940_000,
+                peers = listOf(peer(947_000)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when within tolerance of peer tip`() {
+        // 947_000 - 946_995 = 5 blocks behind, well within the 12-block tolerance.
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 946_995,
+                peers = listOf(peer(947_000)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when our height matches the peer tip`() {
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 947_000,
+                peers = listOf(peer(947_000), peer(946_998)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when no peers are connected to compare against`() {
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 17_904,
+                peers = emptyList(),
+            )
+        )
+    }
+
+    @Test
+    fun `uses the highest peer initial height as the tip estimate`() {
+        // One outlier peer is far ahead — that's what we want to compare against.
+        assertTrue(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 100_000,
+                peers = listOf(peer(100_001), peer(100_005), peer(947_000)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when peer reports zero or negative initial height`() {
+        // Some peers may not have reported a height yet.
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 17_904,
+                peers = listOf(peer(0), peer(-1)),
+            )
+        )
+    }
+
+    @Test
+    fun `not stalled when our height is unknown - guards startup race`() {
+        assertFalse(
+            isLikelyStalled(
+                progress = 1f,
+                ibd = false,
+                ourHeight = 0,
+                peers = listOf(peer(947_000)),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #63.

The daemon's `getblockchaininfo` computes `progress = validated / height`, so any time both numbers stall together (e.g. `flat_chain_store` raising `IndexIsFull` repeatedly on flaky storage like an SD card or adopted external storage), it reports `progress = 1.0` and `ibd = false` even though headers never reached the actual chain tip. The notification then displays "**Mandacaru · Fully synced** — Synced - Block #17,904", which is what the user in #63 saw after ~14 hours stuck on adopted SD-card storage.

This change makes Mandacaru cross-check the daemon's claim against peers' `initial_height` before declaring "Fully synced", and surfaces a warning card when the cross-check fails.

### Behavior

- New `isLikelyStalled(progress, ibd, ourHeight, peers)` helper: returns true only when `!ibd && progress >= 1f` AND `ourHeight + 12 < max(peers.initialHeight)`. The 12-block tolerance (~2h on mainnet) avoids flagging the brief window after assume-utreexo crosses or transient new-block lag.
- Foreground-service notification: when stalled, shows **"Sync stalled at block #N / Storage may be unhealthy"** in the primary-orange color instead of the green "Fully synced" copy.
- Wallet rescan trigger: gated on `!stalled` so we don't keep firing rescans against a frozen chain.
- Node screen: sync card title flips to "Sync stalled", the misleading "100.00%" is hidden, the progress bar turns red/empty, and a new `SyncStalledWarningCard` appears above the sync card with a one-liner suggesting a reinstall on internal storage.

### What this does NOT fix

The underlying daemon misbehavior (`progress = validated/height` being meaningless when both stall, plus `IndexIsFull` / `BlockNotPresent` being silently retried instead of surfaced) is upstream in the floresta-mandacaru fork. Mandacaru just stops lying about it. A separate Floresta-mandacaru patch is warranted.

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (added 9 cases in `IsLikelyStalledTest` covering the issue 63 scenario, IBD guard, sub-100% guard, tolerance window, empty/zero/negative peer heights, and the unknown-own-height startup race)
- [ ] Manual: install on a device, confirm "Fully synced" still appears for a healthy synced node
- [ ] Manual: simulate the stalled state by editing the sync card preview / forcing `isStalled = true` and visually verify the warning card and modified sync card render correctly in light + dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)