### PR TITLE
fix: keep snackbars above the bottom navigation bar (#82)

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
@@ -113,7 +113,10 @@ fun ScreenBlockchainContent(
     Scaffold(
         modifier = modifier,
         snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
+            SnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(bottom = bottomContentPadding),
+            )
         },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -134,7 +134,12 @@ fun ScreenNode(
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.padding(bottom = bottomContentPadding),
+            )
+        },
         containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets(0),
     ) { padding ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -166,7 +166,10 @@ private fun ScreenSettings(
     Scaffold(
         modifier = modifier,
         snackbarHost = {
-            SnackbarHost(hostState = snackBarHostState)
+            SnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(bottom = bottomContentPadding),
+            )
         },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
@@ -118,7 +118,12 @@ fun ScreenTransactionContent(
 
     Scaffold(
         modifier = modifier,
-        snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(bottom = bottomContentPadding),
+            )
+        },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->
         val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass


### PR DESCRIPTION
## Summary

Fixes #82 — snackbars (e.g. the connection / error message shown on **Settings** when adding a node) were hidden behind the floating bottom navigation bar, with only the left/right edges peeking out.

### Root cause
`MainScreen` (`MainActivity.kt`) hosts the floating `AppNavigationBar` as its `bottomBar`, applies only the top inset to the pager content, and passes the bottom inset down to each screen as `bottomContentPadding`. Each screen then renders its **own nested `Scaffold`** with `contentWindowInsets = WindowInsets(0)` and its own `SnackbarHost`. That nested Scaffold extends underneath the parent's floating nav bar, so the `SnackbarHost` is laid out at the very bottom of the screen — directly beneath the nav bar.

### Fix
Apply `Modifier.padding(bottom = bottomContentPadding)` to each screen's `SnackbarHost`. `bottomContentPadding` is already threaded from `MainScreen` for exactly this purpose (lists already use it for their content padding).

One atomic commit per screen:
- Settings (the screen reported in the issue)
- Node
- Blockchain
- Transaction

## Test plan

- [x] Run `./gradlew assembleDebug` and install on an ARM64 device/emulator (`./gradlew installDebug`); Android 12 if available, to match the reporter's setup.
- [x] Go to **Settings**, enter a node address and tap connect → confirm the "Attempting connection to …" snackbar (and any subsequent error snackbar) appears fully visible *above* the floating bottom nav bar, with the text readable.
- [x] Spot-check the other screens that show snackbars (Node snapshot message, Blockchain, Transaction) to confirm their snackbars also clear the nav bar.
- [x] Verify the tablet/rail layout (wide window) is unchanged — when `useRail` is true there is no `bottomBar`, so `bottomContentPadding` is ~0 and behavior is unchanged.

https://claude.ai/code/session_01T4iNAkWV5BzE5koawGTsfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4iNAkWV5BzE5koawGTsfd)_