### PR TITLE
feat: validate peer address with 500ms debounce in Settings

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -533,6 +533,10 @@ private fun ScreenSettings(
                                 maxLines = 1,
                                 singleLine = true,
                                 shape = RoundedCornerShape(12.dp),
+                                isError = uiState.nodeAddressError != null,
+                                supportingText = uiState.nodeAddressError?.let { resId ->
+                                    { Text(stringResource(resId)) }
+                                },
                                 keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
                                 keyboardActions = KeyboardActions(
                                     onDone = { onAction(SettingsAction.OnClickConnectNode) }
@@ -563,7 +567,7 @@ private fun ScreenSettings(
 
                             Button(
                                 onClick = { onAction(SettingsAction.OnClickConnectNode) },
-                                enabled = !uiState.isLoading && uiState.nodeAddress.isNotBlank(),
+                                enabled = !uiState.isLoading && uiState.isNodeAddressValid,
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = RoundedCornerShape(12.dp)
                             ) {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -10,6 +10,8 @@ data class SettingsUiState(
     val descriptorText: String = "",
     val electrumAddress: String = "",
     val nodeAddress: String = "",
+    val nodeAddressError: Int? = null,
+    val isNodeAddressValid: Boolean = false,
     val snackBarMessage: String = "",
     val selectedNetwork: String = "",
     val isLoading: Boolean = false,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -8,10 +8,12 @@ import androidx.lifecycle.viewModelScope
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
+import com.github.jvsena42.mandacaru.presentation.utils.PeerAddressValidator
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
 import com.github.jvsena42.mandacaru.presentation.utils.getElectrumPort
 import com.github.jvsena42.mandacaru.presentation.utils.getNetwork
@@ -19,12 +21,14 @@ import com.github.jvsena42.mandacaru.presentation.utils.getRpcPort
 import com.github.jvsena42.mandacaru.presentation.utils.removeSpaces
 import kotlinx.coroutines.Dispatchers
 import java.io.File
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import com.florestad.Network as FlorestaNetwork
 
@@ -37,6 +41,8 @@ class SettingsViewModel(
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState = _uiState.asStateFlow()
+
+    private var nodeAddressValidationJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -71,8 +77,15 @@ class SettingsViewModel(
             SettingsAction.OnClickRescan -> rescan()
             SettingsAction.ClearSnackBarMessage -> _uiState.update { it.copy(snackBarMessage = "") }
             SettingsAction.OnClickConnectNode -> connectNode()
-            is SettingsAction.OnNodeAddressChanged -> _uiState.update {
-                it.copy(nodeAddress = action.address.removeSpaces())
+            is SettingsAction.OnNodeAddressChanged -> {
+                _uiState.update {
+                    it.copy(
+                        nodeAddress = action.address.removeSpaces(),
+                        nodeAddressError = null,
+                        isNodeAddressValid = false,
+                    )
+                }
+                debouncedValidateNodeAddress()
             }
 
             is SettingsAction.OnNetworkSelected -> handleNetworkSelected(action)
@@ -183,7 +196,45 @@ class SettingsViewModel(
         }
     }
 
+    private fun debouncedValidateNodeAddress() {
+        nodeAddressValidationJob?.cancel()
+        nodeAddressValidationJob = viewModelScope.launch {
+            delay(VALIDATION_DEBOUNCE_MS.milliseconds)
+            val address = _uiState.value.nodeAddress
+            val result = PeerAddressValidator.validate(address)
+            _uiState.update {
+                when (result) {
+                    PeerAddressValidator.Result.Valid -> it.copy(
+                        isNodeAddressValid = true,
+                        nodeAddressError = null,
+                    )
+                    PeerAddressValidator.Result.Empty -> it.copy(
+                        isNodeAddressValid = false,
+                        nodeAddressError = null,
+                    )
+                    PeerAddressValidator.Result.InvalidIpv4 -> it.copy(
+                        isNodeAddressValid = false,
+                        nodeAddressError = R.string.node_address_error_invalid_ipv4,
+                    )
+                    PeerAddressValidator.Result.InvalidIpv6 -> it.copy(
+                        isNodeAddressValid = false,
+                        nodeAddressError = R.string.node_address_error_invalid_ipv6,
+                    )
+                    PeerAddressValidator.Result.InvalidPort -> it.copy(
+                        isNodeAddressValid = false,
+                        nodeAddressError = R.string.node_address_error_invalid_port,
+                    )
+                    PeerAddressValidator.Result.InvalidFormat -> it.copy(
+                        isNodeAddressValid = false,
+                        nodeAddressError = R.string.node_address_error_invalid_format,
+                    )
+                }
+            }
+        }
+    }
+
     private fun connectNode() {
+        if (!_uiState.value.isNodeAddressValid) return
         val address = _uiState.value.nodeAddress
         if (address.isEmpty()) return
         _uiState.update { it.copy(isLoading = true) }
@@ -195,6 +246,8 @@ class SettingsViewModel(
                 _uiState.update {
                     it.copy(
                         nodeAddress = "",
+                        nodeAddressError = null,
+                        isNodeAddressValid = false,
                         snackBarMessage = "Attempting connection to $address…"
                     )
                 }
@@ -279,7 +332,13 @@ class SettingsViewModel(
         }
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        nodeAddressValidationJob?.cancel()
+    }
+
     companion object {
         private const val TAG = "SettingsViewModel"
+        private const val VALIDATION_DEBOUNCE_MS = 500L
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/PeerAddressValidator.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/PeerAddressValidator.kt
@@ -1,0 +1,114 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+/**
+ * Client-side validator for the "Add Peer" address field. Accepts:
+ *  - IPv4 with optional ":port"        e.g. 189.44.63.101 or 189.44.63.101:8333
+ *  - Bracketed IPv6 with optional port e.g. [2001:db8::1] or [2001:db8::1]:8333
+ *
+ * Hostnames and .onion addresses are intentionally rejected — the Settings
+ * hint string only documents IPv4 and bracketed IPv6.
+ */
+object PeerAddressValidator {
+
+    sealed interface Result {
+        object Valid : Result
+        object Empty : Result
+        object InvalidFormat : Result
+        object InvalidIpv4 : Result
+        object InvalidIpv6 : Result
+        object InvalidPort : Result
+    }
+
+    fun validate(input: String): Result {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return Result.Empty
+
+        if (trimmed.startsWith("[")) {
+            val close = trimmed.indexOf(']')
+            if (close < 0) return Result.InvalidIpv6
+            val host = trimmed.substring(1, close)
+            val rest = trimmed.substring(close + 1)
+            if (!isValidIpv6(host)) return Result.InvalidIpv6
+            return validatePortSuffix(rest, Result.InvalidPort)
+        }
+
+        val colonCount = trimmed.count { it == ':' }
+        if (colonCount > 1) return Result.InvalidFormat
+
+        val (host, portPart) = if (colonCount == 1) {
+            val idx = trimmed.indexOf(':')
+            trimmed.substring(0, idx) to trimmed.substring(idx)
+        } else {
+            trimmed to ""
+        }
+
+        if (!isValidIpv4(host)) return Result.InvalidIpv4
+        return validatePortSuffix(portPart, Result.InvalidPort)
+    }
+
+    private fun validatePortSuffix(portPart: String, onInvalid: Result): Result {
+        if (portPart.isEmpty()) return Result.Valid
+        if (!portPart.startsWith(":")) return onInvalid
+        val portStr = portPart.substring(1)
+        if (portStr.isEmpty()) return onInvalid
+        if (portStr.any { !it.isDigit() }) return onInvalid
+        val port = portStr.toIntOrNull() ?: return onInvalid
+        if (port !in 1..65535) return onInvalid
+        return Result.Valid
+    }
+
+    private fun isValidIpv4(host: String): Boolean {
+        val octets = host.split('.')
+        if (octets.size != 4) return false
+        for (octet in octets) {
+            if (octet.isEmpty() || octet.length > 3) return false
+            if (octet.any { !it.isDigit() }) return false
+            // Reject leading zeros ("01", "001") to avoid octal-style ambiguity.
+            if (octet.length > 1 && octet[0] == '0') return false
+            val value = octet.toIntOrNull() ?: return false
+            if (value !in 0..255) return false
+        }
+        return true
+    }
+
+    private fun isValidIpv6(host: String): Boolean {
+        if (host.isEmpty()) return false
+        // At most one "::" compression.
+        val doubleColonCount = countOccurrences(host, "::")
+        if (doubleColonCount > 1) return false
+
+        val hasDoubleColon = doubleColonCount == 1
+        val groups: List<String> = if (hasDoubleColon) {
+            val (left, right) = host.split("::", limit = 2).let { it[0] to it[1] }
+            val leftGroups = if (left.isEmpty()) emptyList() else left.split(':')
+            val rightGroups = if (right.isEmpty()) emptyList() else right.split(':')
+            // With compression total non-empty groups must be < 8.
+            if (leftGroups.size + rightGroups.size >= 8) return false
+            leftGroups + rightGroups
+        } else {
+            val parts = host.split(':')
+            if (parts.size != 8) return false
+            parts
+        }
+
+        for (group in groups) {
+            if (group.isEmpty() || group.length > 4) return false
+            if (group.any { !it.isHexDigit() }) return false
+        }
+        return true
+    }
+
+    private fun countOccurrences(haystack: String, needle: String): Int {
+        var count = 0
+        var idx = 0
+        while (true) {
+            val found = haystack.indexOf(needle, idx)
+            if (found < 0) return count
+            count++
+            idx = found + needle.length
+        }
+    }
+
+    private fun Char.isHexDigit(): Boolean =
+        this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="connect_directly_with_a_node">Node address (ip:port)</string>
     <string name="connect">Connect</string>
     <string name="node_address_hint">Accepts IPv4 (e.g. 189.44.63.101:8333) and IPv6 (e.g. [2001:db8::1]:8333). Port defaults to 8333 if omitted.</string>
+    <string name="node_address_error_invalid_format">Invalid address format. Use IPv4 (1.2.3.4[:port]) or bracketed IPv6 ([::1]:port).</string>
+    <string name="node_address_error_invalid_ipv4">Invalid IPv4 address.</string>
+    <string name="node_address_error_invalid_ipv6">Invalid IPv6 address. Use brackets, e.g. [2001:db8::1]:8333.</string>
+    <string name="node_address_error_invalid_port">Invalid port. Must be between 1 and 65535.</string>
     <string name="select_a_network">Select a network</string>
     <string name="the_application_will_be_restarted_to_update_the_network">The application will be restarted to update the network</string>
     <string name="validated_blocks">Validated Blocks</string>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/PeerAddressValidatorTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/PeerAddressValidatorTest.kt
@@ -1,0 +1,210 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import com.github.jvsena42.mandacaru.presentation.utils.PeerAddressValidator.Result
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PeerAddressValidatorTest {
+
+    // --- Valid IPv4 ---
+
+    @Test
+    fun `valid IPv4 with port`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("189.44.63.101:8333"))
+    }
+
+    @Test
+    fun `valid IPv4 with non-default port`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("195.26.240.213:8433"))
+    }
+
+    @Test
+    fun `valid IPv4 without port`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("161.97.178.61"))
+    }
+
+    @Test
+    fun `valid IPv4 lower boundary`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("0.0.0.0"))
+    }
+
+    @Test
+    fun `valid IPv4 upper boundary`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("255.255.255.255"))
+    }
+
+    @Test
+    fun `valid IPv4 with min port 1`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("1.2.3.4:1"))
+    }
+
+    @Test
+    fun `valid IPv4 with max port 65535`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("1.2.3.4:65535"))
+    }
+
+    @Test
+    fun `valid IPv4 is trimmed of surrounding whitespace`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("  189.44.63.101:8333  "))
+    }
+
+    // --- Valid IPv6 ---
+
+    @Test
+    fun `valid bracketed IPv6 with port`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("[2001:db8::1]:8333"))
+    }
+
+    @Test
+    fun `valid bracketed IPv6 full form with port`() {
+        assertEquals(
+            Result.Valid,
+            PeerAddressValidator.validate("[2001:fb1:42:567:ea9c:25ff:fe79:744]:8333")
+        )
+    }
+
+    @Test
+    fun `valid bracketed IPv6 loopback without port`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("[::1]"))
+    }
+
+    @Test
+    fun `valid bracketed IPv6 all-zero compressed`() {
+        assertEquals(Result.Valid, PeerAddressValidator.validate("[::]"))
+    }
+
+    // --- Empty / whitespace ---
+
+    @Test
+    fun `empty string is Empty`() {
+        assertEquals(Result.Empty, PeerAddressValidator.validate(""))
+    }
+
+    @Test
+    fun `whitespace only is Empty`() {
+        assertEquals(Result.Empty, PeerAddressValidator.validate("   "))
+    }
+
+    // --- Invalid IPv4 ---
+
+    @Test
+    fun `IPv4 octet above 255 is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("256.0.0.1"))
+    }
+
+    @Test
+    fun `IPv4 with too few octets is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("1.2.3"))
+    }
+
+    @Test
+    fun `IPv4 with too many octets is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("1.2.3.4.5"))
+    }
+
+    @Test
+    fun `IPv4 with non-numeric octet is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("a.b.c.d"))
+    }
+
+    @Test
+    fun `IPv4 with leading zero octet is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("01.2.3.4"))
+    }
+
+    @Test
+    fun `IPv4 with empty octet is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("1..3.4"))
+    }
+
+    @Test
+    fun `IPv4 with trailing dot is invalid`() {
+        assertEquals(Result.InvalidIpv4, PeerAddressValidator.validate("1.2.3.4."))
+    }
+
+    // --- Invalid IPv6 / format ---
+
+    @Test
+    fun `bare unbracketed IPv6 is invalid format`() {
+        // Multiple colons without brackets is not IPv4-with-port and not bracketed IPv6.
+        assertEquals(Result.InvalidFormat, PeerAddressValidator.validate("2001:db8::1:8333"))
+    }
+
+    @Test
+    fun `missing closing bracket is invalid IPv6`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[2001:db8::1"))
+    }
+
+    @Test
+    fun `non-hex inside brackets is invalid IPv6`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[zzz]"))
+    }
+
+    @Test
+    fun `empty brackets is invalid IPv6`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[]:8333"))
+    }
+
+    @Test
+    fun `IPv6 with double compression is invalid`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[2001::1::2]:8333"))
+    }
+
+    @Test
+    fun `IPv6 group longer than 4 chars is invalid`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[20011:db8::1]:8333"))
+    }
+
+    @Test
+    fun `IPv6 uncompressed with wrong number of groups is invalid`() {
+        assertEquals(Result.InvalidIpv6, PeerAddressValidator.validate("[2001:db8:1:2:3:4:5]"))
+    }
+
+    // --- Invalid port ---
+
+    @Test
+    fun `IPv4 with empty port is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("1.2.3.4:"))
+    }
+
+    @Test
+    fun `IPv4 with port zero is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("1.2.3.4:0"))
+    }
+
+    @Test
+    fun `IPv4 with port above max is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("1.2.3.4:65536"))
+    }
+
+    @Test
+    fun `IPv4 with non-numeric port is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("1.2.3.4:abc"))
+    }
+
+    @Test
+    fun `IPv4 with signed port is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("1.2.3.4:-1"))
+    }
+
+    @Test
+    fun `IPv6 with empty port is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("[2001:db8::1]:"))
+    }
+
+    @Test
+    fun `IPv6 with port above max is invalid port`() {
+        assertEquals(Result.InvalidPort, PeerAddressValidator.validate("[2001:db8::1]:65536"))
+    }
+
+    // --- Sanity: ensure all Invalid* results are distinct types ---
+
+    @Test
+    fun `invalid results are distinct types`() {
+        assertTrue(PeerAddressValidator.validate("256.0.0.1") is Result.InvalidIpv4)
+        assertTrue(PeerAddressValidator.validate("[zzz]") is Result.InvalidIpv6)
+        assertTrue(PeerAddressValidator.validate("1.2.3.4:0") is Result.InvalidPort)
+        assertTrue(PeerAddressValidator.validate("2001:db8::1:8333") is Result.InvalidFormat)
+    }
+}


### PR DESCRIPTION
Adds client-side validation for the Node address field so users get
immediate feedback instead of waiting for the Floresta daemon to reject
malformed input. Accepts IPv4 (a.b.c.d[:port]) and bracketed IPv6
([..][:port]) with port in 1..65535, matching the existing hint text.

- PeerAddressValidator returns a sealed Result (Valid/Empty/InvalidIpv4/
  InvalidIpv6/InvalidPort/InvalidFormat).
- SettingsViewModel runs validation through a 500ms debounce job
  (mirroring TransactionViewModel.debouncedSearch), gates connectNode on
  isNodeAddressValid, and cancels the job in onCleared.
- ScreenSettings surfaces errors via isError/supportingText on the
  OutlinedTextField; Connect button stays disabled until valid.
- 36 JUnit tests cover valid forms, empty input, and each invalid case.

https://claude.ai/code/session_012mABqpoypXmQehw18AoPVf