### PR TITLE
feat: broadcast signed transactions from airgapped wallets via QR scan

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,9 @@ dependencies {
     implementation(libs.androidx.camera.view)
     implementation(libs.mlkit.barcode.scanning)
 
+    implementation(libs.hummingbird)
+    implementation(libs.bdk.android)
+
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.koin.viewmodel)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
@@ -14,6 +14,10 @@ import com.github.jvsena42.mandacaru.data.floresta.FlorestaRpcImpl
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
+import com.github.jvsena42.mandacaru.domain.scan.BdkTransactionDecoder
+import com.github.jvsena42.mandacaru.domain.scan.DefaultQrTransactionScanner
+import com.github.jvsena42.mandacaru.domain.scan.QrTransactionScanner
+import com.github.jvsena42.mandacaru.domain.scan.TransactionDecoder
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.BlockchainViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.NodeViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.transaction.TransactionViewModel
@@ -56,7 +60,13 @@ val presentationModule = module {
         )
     }
     viewModel { SettingsViewModel(florestaRpc = get(), preferencesDataSource = get(), context = androidContext()) }
-    viewModel { TransactionViewModel(florestaRpc = get()) }
+    viewModel {
+        TransactionViewModel(
+            florestaRpc = get(),
+            qrScanner = get(),
+            transactionDecoder = get(),
+        )
+    }
     viewModel { BlockchainViewModel(florestaRpc = get()) }
 }
 
@@ -75,4 +85,6 @@ val dataModule = module {
     }
     single { UtreexoBridgeAutoConnect(florestaRpc = get(), preferencesDataSource = get()) }
     single { UtreexoSnapshotService(daemon = get()) }
+    factory<QrTransactionScanner> { DefaultQrTransactionScanner() }
+    single<TransactionDecoder> { BdkTransactionDecoder() }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/BbqrJoiner.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/BbqrJoiner.kt
@@ -1,0 +1,121 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.Inflater
+
+/**
+ * Pure-Kotlin joiner for animated BBQr sequences (https://bbqr.org). Each scanned part carries an
+ * 8-char header `B$` + encoding + file type + base36 total + base36 index, followed by the encoded
+ * chunk. Chunks are concatenated by index and decoded once the whole sequence has arrived. Kept
+ * dependency-free on purpose so there is no native library to keep 16 KB-page aligned.
+ */
+class BbqrJoiner {
+
+    sealed interface Result {
+        data class InProgress(val received: Int, val total: Int) : Result
+        class Complete(val data: ByteArray) : Result
+    }
+
+    private var encoding: Char? = null
+    private var fileType: Char? = null
+    private var total = 0
+    private val chunks = HashMap<Int, String>()
+
+    fun addPart(raw: String): Result {
+        require(raw.length >= HEADER_LENGTH && raw.startsWith(PREFIX)) { "Not a BBQr part" }
+        val partEncoding = raw[ENCODING_INDEX]
+        val partType = raw[FILE_TYPE_INDEX]
+        val partTotal = raw.substring(TOTAL_START, TOTAL_END).toInt(BASE36)
+        val index = raw.substring(INDEX_START, HEADER_LENGTH).toInt(BASE36)
+
+        require(partTotal in 1..MAX_PARTS) { "Invalid BBQr part count" }
+        require(index in 0 until partTotal) { "Invalid BBQr part index" }
+
+        if (encoding == null) {
+            encoding = partEncoding
+            fileType = partType
+            total = partTotal
+        } else {
+            require(partEncoding == encoding && partType == fileType && partTotal == total) {
+                "BBQr part from a different sequence"
+            }
+        }
+
+        chunks[index] = raw.substring(HEADER_LENGTH)
+        return if (chunks.size < total) {
+            Result.InProgress(chunks.size, total)
+        } else {
+            Result.Complete(decodeJoined())
+        }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun decodeJoined(): ByteArray {
+        val joined = buildString { for (i in 0 until total) append(chunks.getValue(i)) }
+        return when (encoding) {
+            ENCODING_HEX -> joined.lowercase().hexToByteArray()
+            ENCODING_BASE32 -> Base32.decode(joined)
+            ENCODING_ZLIB -> inflateRaw(Base32.decode(joined))
+            else -> throw IllegalArgumentException("Unsupported BBQr encoding: $encoding")
+        }
+    }
+
+    private fun inflateRaw(data: ByteArray): ByteArray {
+        val inflater = Inflater(true)
+        inflater.setInput(data)
+        val output = ByteArrayOutputStream(data.size * INFLATE_GROWTH)
+        val buffer = ByteArray(INFLATE_BUFFER)
+        try {
+            var produced = inflater.inflate(buffer)
+            while (produced > 0) {
+                output.write(buffer, 0, produced)
+                produced = inflater.inflate(buffer)
+            }
+        } finally {
+            inflater.end()
+        }
+        return output.toByteArray()
+    }
+
+    private companion object {
+        const val PREFIX = "B$"
+        const val HEADER_LENGTH = 8
+        const val ENCODING_INDEX = 2
+        const val FILE_TYPE_INDEX = 3
+        const val TOTAL_START = 4
+        const val TOTAL_END = 6
+        const val INDEX_START = 6
+        const val BASE36 = 36
+        const val MAX_PARTS = 1295
+        const val ENCODING_HEX = 'H'
+        const val ENCODING_BASE32 = '2'
+        const val ENCODING_ZLIB = 'Z'
+        const val INFLATE_BUFFER = 4096
+        const val INFLATE_GROWTH = 4
+    }
+}
+
+internal object Base32 {
+    private const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    private const val BITS_PER_CHAR = 5
+    private const val BITS_PER_BYTE = 8
+    private const val BYTE_MASK = 0xFF
+
+    fun decode(input: String): ByteArray {
+        val output = ByteArrayOutputStream(input.length * BITS_PER_CHAR / BITS_PER_BYTE)
+        var buffer = 0
+        var bits = 0
+        for (symbol in input) {
+            if (symbol == '=') continue
+            val value = ALPHABET.indexOf(symbol.uppercaseChar())
+            require(value >= 0) { "Invalid base32 character: $symbol" }
+            buffer = (buffer shl BITS_PER_CHAR) or value
+            bits += BITS_PER_CHAR
+            if (bits >= BITS_PER_BYTE) {
+                bits -= BITS_PER_BYTE
+                output.write((buffer ushr bits) and BYTE_MASK)
+            }
+        }
+        return output.toByteArray()
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/DecodedTransaction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/DecodedTransaction.kt
@@ -1,0 +1,19 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+enum class PayloadType { PSBT, TRANSACTION }
+
+enum class ScanTransport { SINGLE, UR, BBQR }
+
+data class DecodedTransaction(
+    val rawHex: String,
+    val txid: String,
+    val inputCount: Int,
+    val outputCount: Int,
+    val totalOutSats: Long,
+    val feeSats: Long?,
+    val feeRateSatVb: Double?,
+    val vsize: Long,
+    val weight: Long,
+    val payloadType: PayloadType,
+    val transport: ScanTransport,
+)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScanner.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScanner.kt
@@ -1,0 +1,100 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+import com.sparrowwallet.hummingbird.ResultType
+import com.sparrowwallet.hummingbird.UR
+import com.sparrowwallet.hummingbird.URDecoder
+import java.util.Base64
+
+interface QrTransactionScanner {
+    fun ingest(raw: String): ScanState
+    fun reset()
+}
+
+/**
+ * Accumulates scanned QR strings into a single signed payload. Handles single-frame raw hex /
+ * base64 / PSBT, animated UR/BCUR (hummingbird) and animated BBQr (bbqr-android). The transport is
+ * locked in by the first frame and stays until [reset] or completion.
+ */
+class DefaultQrTransactionScanner : QrTransactionScanner {
+
+    private var urDecoder: URDecoder? = null
+    private var bbqrJoiner: BbqrJoiner? = null
+
+    override fun ingest(raw: String): ScanState {
+        val text = raw.trim()
+        if (text.isEmpty()) return ScanState.Idle
+        return when {
+            text.startsWith(UR_PREFIX, ignoreCase = true) -> ingestUr(text)
+            text.startsWith(BBQR_PREFIX) -> ingestBbqr(text)
+            else -> ingestSingleFrame(text)
+        }
+    }
+
+    override fun reset() {
+        urDecoder = null
+        bbqrJoiner = null
+    }
+
+    private fun ingestUr(part: String): ScanState {
+        val decoder = urDecoder ?: URDecoder().also { urDecoder = it }
+        decoder.receivePart(part)
+        val result = decoder.result ?: return ScanState.InProgress(
+            decoder.estimatedPercentComplete.toFloat().coerceIn(0f, PROGRESS_CEILING)
+        )
+        return when (result.type) {
+            ResultType.SUCCESS -> completeWith(result.ur, ScanTransport.UR)
+            else -> failWith(result.error ?: "Failed to decode the animated QR code")
+        }
+    }
+
+    private fun completeWith(ur: UR, transport: ScanTransport): ScanState =
+        try {
+            ScanState.Complete(ur.toBytes(), transport).also { reset() }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            failWith(e.message ?: "Unsupported QR payload")
+        }
+
+    private fun ingestBbqr(part: String): ScanState {
+        val joiner = bbqrJoiner ?: BbqrJoiner().also { bbqrJoiner = it }
+        return try {
+            when (val result = joiner.addPart(part)) {
+                is BbqrJoiner.Result.InProgress -> {
+                    val progress = result.received.toFloat() / result.total
+                    ScanState.InProgress(progress.coerceIn(0f, PROGRESS_CEILING))
+                }
+                is BbqrJoiner.Result.Complete ->
+                    ScanState.Complete(result.data, ScanTransport.BBQR).also { reset() }
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            failWith(e.message ?: "Failed to decode the BBQr code")
+        }
+    }
+
+    private fun ingestSingleFrame(text: String): ScanState {
+        val bytes = decodeSingleFrame(text)
+            ?: return failWith("Unrecognized QR code content")
+        return ScanState.Complete(bytes, ScanTransport.SINGLE).also { reset() }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun decodeSingleFrame(text: String): ByteArray? {
+        val candidate = text.removePrefix(HEX_PREFIX)
+        if (candidate.length % 2 == 0 && candidate.matches(HEX_REGEX)) {
+            return candidate.hexToByteArray()
+        }
+        return runCatching { Base64.getDecoder().decode(text) }.getOrNull()
+    }
+
+    private fun failWith(reason: String): ScanState {
+        reset()
+        return ScanState.Error(reason)
+    }
+
+    private companion object {
+        const val UR_PREFIX = "ur:"
+        const val BBQR_PREFIX = "B$"
+        const val HEX_PREFIX = "0x"
+        const val PROGRESS_CEILING = 0.99f
+        val HEX_REGEX = Regex("^[0-9a-fA-F]+$")
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/ScanState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/ScanState.kt
@@ -1,0 +1,11 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+sealed interface ScanState {
+    data object Idle : ScanState
+
+    data class InProgress(val progress: Float) : ScanState
+
+    class Complete(val payload: ByteArray, val transport: ScanTransport) : ScanState
+
+    data class Error(val reason: String) : ScanState
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/TransactionDecoder.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/TransactionDecoder.kt
@@ -1,0 +1,85 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+import org.bitcoindevkit.Psbt
+import org.bitcoindevkit.Transaction
+import java.util.Base64
+
+class TransactionDecodeException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+interface TransactionDecoder {
+    fun decode(payload: ByteArray, transport: ScanTransport): Result<DecodedTransaction>
+}
+
+/**
+ * Turns a scanned payload into a broadcastable raw transaction. A PSBT (detected by its magic
+ * bytes) is finalized and extracted, exposing its fee; a raw signed transaction is parsed directly
+ * (its fee is unknown because the input amounts are not part of the serialization). Failures are
+ * surfaced as a [TransactionDecodeException] wrapped in the returned [Result].
+ */
+class BdkTransactionDecoder : TransactionDecoder {
+
+    override fun decode(payload: ByteArray, transport: ScanTransport): Result<DecodedTransaction> =
+        runCatching {
+            if (isPsbt(payload)) decodePsbt(payload, transport) else decodeRawTransaction(payload, transport)
+        }
+
+    private fun decodePsbt(payload: ByteArray, transport: ScanTransport): DecodedTransaction {
+        val psbt = try {
+            Psbt(Base64.getEncoder().encodeToString(payload))
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            throw TransactionDecodeException("Couldn't read the scanned PSBT.", e)
+        }
+        return psbt.use {
+            val feeSats = runCatching { it.fee().toLong() }.getOrNull()
+            val tx = try {
+                it.extractTx()
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                throw TransactionDecodeException(
+                    "This PSBT isn't finalized yet. Finalize it on your signing device, then scan again.",
+                    e,
+                )
+            }
+            tx.use { finalTx -> summarize(finalTx, feeSats, PayloadType.PSBT, transport) }
+        }
+    }
+
+    private fun decodeRawTransaction(payload: ByteArray, transport: ScanTransport): DecodedTransaction {
+        val tx = try {
+            Transaction(payload)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            throw TransactionDecodeException("Couldn't read the scanned transaction.", e)
+        }
+        return tx.use { summarize(it, feeSats = null, type = PayloadType.TRANSACTION, transport = transport) }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun summarize(
+        tx: Transaction,
+        feeSats: Long?,
+        type: PayloadType,
+        transport: ScanTransport,
+    ): DecodedTransaction {
+        val outputs = tx.output()
+        val vsize = tx.vsize().toLong()
+        return DecodedTransaction(
+            rawHex = tx.serialize().toHexString(),
+            txid = tx.computeTxid().toString(),
+            inputCount = tx.input().size,
+            outputCount = outputs.size,
+            totalOutSats = outputs.sumOf { it.value.toSat().toLong() },
+            feeSats = feeSats,
+            feeRateSatVb = feeSats?.takeIf { vsize > 0 }?.let { it.toDouble() / vsize },
+            vsize = vsize,
+            weight = tx.weight().toLong(),
+            payloadType = type,
+            transport = transport,
+        )
+    }
+
+    private fun isPsbt(payload: ByteArray): Boolean =
+        payload.size >= PSBT_MAGIC.size && PSBT_MAGIC.indices.all { payload[it] == PSBT_MAGIC[it] }
+
+    private companion object {
+        val PSBT_MAGIC = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xFF.toByte())
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Send
 import androidx.compose.material3.Button
@@ -40,6 +41,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -222,6 +224,19 @@ fun ScreenTransactionContent(
                 }
             }
         }
+
+        if (uiState.isScannerVisible) {
+            TransactionScanSheet(uiState = uiState, onAction = onAction)
+        }
+
+        uiState.decodedTx?.let { decoded ->
+            TransactionConfirmSheet(
+                decoded = decoded,
+                isBroadcasting = uiState.isBroadcasting,
+                onConfirm = { onAction(TransactionAction.OnConfirmBroadcast) },
+                onDismiss = { onAction(TransactionAction.OnDismissConfirmation) },
+            )
+        }
     }
 }
 
@@ -386,6 +401,24 @@ internal fun BroadcastTransactionCard(
                 shape = RoundedCornerShape(12.dp)
             ) {
                 Text(stringResource(R.string.broadcast))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = { onAction(TransactionAction.OnClickScan) },
+                enabled = !uiState.isBroadcasting,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(
+                    Icons.Outlined.QrCodeScanner,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Text(
+                    text = " ${stringResource(R.string.scan_to_broadcast)}",
+                )
             }
 
             AnimatedVisibility(

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionAction.kt
@@ -5,4 +5,10 @@ sealed interface TransactionAction {
     data object ClearSnackBarMessage : TransactionAction
     data class OnRawTxChanged(val rawTx: String) : TransactionAction
     data object OnClickBroadcast : TransactionAction
+    data object OnClickScan : TransactionAction
+    data object OnDismissScanner : TransactionAction
+    data class OnQrFrameScanned(val payload: String) : TransactionAction
+    data class OnScanPasteSubmitted(val text: String) : TransactionAction
+    data object OnConfirmBroadcast : TransactionAction
+    data object OnDismissConfirmation : TransactionAction
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionConfirmSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionConfirmSheet.kt
@@ -1,0 +1,292 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.transaction
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.domain.scan.DecodedTransaction
+import com.github.jvsena42.mandacaru.domain.scan.PayloadType
+import com.github.jvsena42.mandacaru.domain.scan.ScanTransport
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionConfirmSheet(
+    decoded: DecodedTransaction,
+    isBroadcasting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        TransactionConfirmContent(
+            decoded = decoded,
+            isBroadcasting = isBroadcasting,
+            onConfirm = onConfirm,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+@Composable
+private fun TransactionConfirmContent(
+    decoded: DecodedTransaction,
+    isBroadcasting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopCenter) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = MAX_CONTENT_WIDTH)
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                stringResource(R.string.confirm_broadcast_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                stringResource(
+                    R.string.confirm_decoded_from,
+                    stringResource(sourceLabel(decoded.payloadType)),
+                    stringResource(transportLabel(decoded.transport)),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            SummaryCard(decoded)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    enabled = !isBroadcasting,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+                Button(
+                    onClick = onConfirm,
+                    enabled = !isBroadcasting,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.broadcast))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(decoded: DecodedTransaction) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            DetailRow(
+                label = stringResource(R.string.confirm_tx_id),
+                value = decoded.txid,
+                isMonospace = true,
+            )
+            Divider()
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                DetailRow(
+                    label = stringResource(R.string.confirm_inputs),
+                    value = decoded.inputCount.toString(),
+                    modifier = Modifier.weight(1f),
+                )
+                DetailRow(
+                    label = stringResource(R.string.confirm_outputs),
+                    value = decoded.outputCount.toString(),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Divider()
+            DetailRow(
+                label = stringResource(R.string.confirm_total_out),
+                value = stringResource(R.string.value_sats, groupSats(decoded.totalOutSats)),
+            )
+            Divider()
+            FeeRow(decoded)
+            decoded.feeRateSatVb?.let { rate ->
+                Divider()
+                DetailRow(
+                    label = stringResource(R.string.confirm_fee_rate),
+                    value = stringResource(R.string.value_sat_vb, formatFeeRate(rate)),
+                )
+            }
+            Divider()
+            DetailRow(
+                label = stringResource(R.string.confirm_virtual_size),
+                value = stringResource(R.string.value_vbytes, groupSats(decoded.vsize)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FeeRow(decoded: DecodedTransaction) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        if (decoded.feeSats != null) {
+            DetailRow(
+                label = stringResource(R.string.confirm_fee),
+                value = stringResource(R.string.value_sats, groupSats(decoded.feeSats)),
+            )
+        } else {
+            DetailRow(
+                label = stringResource(R.string.confirm_fee),
+                value = stringResource(R.string.confirm_fee_unavailable),
+            )
+            Text(
+                stringResource(R.string.confirm_fee_unavailable_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    isMonospace: Boolean = false,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = LABEL_ALPHA),
+            fontWeight = FontWeight.Medium,
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = if (isMonospace) FontFamily.Monospace else FontFamily.Default,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = VALUE_BG_ALPHA))
+                .padding(8.dp),
+        )
+    }
+}
+
+@Composable
+private fun Divider() {
+    HorizontalDivider(modifier = Modifier.padding(vertical = 10.dp))
+}
+
+private fun sourceLabel(type: PayloadType): Int = when (type) {
+    PayloadType.PSBT -> R.string.confirm_source_psbt
+    PayloadType.TRANSACTION -> R.string.confirm_source_transaction
+}
+
+private fun transportLabel(transport: ScanTransport): Int = when (transport) {
+    ScanTransport.SINGLE -> R.string.confirm_transport_single
+    ScanTransport.UR -> R.string.confirm_transport_ur
+    ScanTransport.BBQR -> R.string.confirm_transport_bbqr
+}
+
+private fun groupSats(value: Long): String = String.format(Locale.getDefault(), "%,d", value)
+
+private fun formatFeeRate(rate: Double): String = String.format(Locale.getDefault(), "%.1f", rate)
+
+private const val LABEL_ALPHA = 0.7f
+private const val VALUE_BG_ALPHA = 0.3f
+private val MAX_CONTENT_WIDTH = 560.dp
+
+@PreviewLightDark
+@Composable
+private fun TransactionConfirmContentPreview() {
+    MandacaruTheme {
+        Surface {
+            TransactionConfirmContent(
+                decoded = DecodedTransaction(
+                    rawHex = "0200000001abcdef…",
+                    txid = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+                    inputCount = 1,
+                    outputCount = 2,
+                    totalOutSats = 1_234_567,
+                    feeSats = 2_500,
+                    feeRateSatVb = 12.3,
+                    vsize = 141,
+                    weight = 562,
+                    payloadType = PayloadType.PSBT,
+                    transport = ScanTransport.UR,
+                ),
+                isBroadcasting = false,
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun TransactionConfirmContentRawTxPreview() {
+    MandacaruTheme {
+        Surface {
+            TransactionConfirmContent(
+                decoded = DecodedTransaction(
+                    rawHex = "0200000001abcdef…",
+                    txid = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+                    inputCount = 2,
+                    outputCount = 1,
+                    totalOutSats = 980_000,
+                    feeSats = null,
+                    feeRateSatVb = null,
+                    vsize = 222,
+                    weight = 888,
+                    payloadType = PayloadType.TRANSACTION,
+                    transport = ScanTransport.BBQR,
+                ),
+                isBroadcasting = false,
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
@@ -1,0 +1,338 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.transaction
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentPaste
+import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionScanSheet(
+    uiState: TransactionUiState,
+    onAction: (TransactionAction) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var hasCamera by remember { mutableStateOf(false) }
+    var pasteMode by remember { mutableStateOf(false) }
+    var pasteText by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = { onAction(TransactionAction.OnDismissScanner) },
+        sheetState = sheetState,
+    ) {
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopCenter) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = MAX_CONTENT_WIDTH)
+                    .fillMaxWidth()
+                    .fillMaxHeight(SHEET_HEIGHT_FRACTION)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    stringResource(R.string.scan_transaction_title),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                Text(
+                    stringResource(R.string.scan_transaction_hint),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+
+                ScanStatus(uiState = uiState)
+
+                if (pasteMode) {
+                    PasteSection(
+                        text = pasteText,
+                        onTextChange = { pasteText = it },
+                        enabled = !uiState.isDecoding,
+                        onSubmit = { onAction(TransactionAction.OnScanPasteSubmitted(pasteText.trim())) },
+                        onBackToCamera = { pasteMode = false },
+                    )
+                } else {
+                    RequestCameraPermission(onPermissionChange = { hasCamera = it })
+                    if (hasCamera) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            ContinuousCameraPreview(
+                                onPayloadScanned = { onAction(TransactionAction.OnQrFrameScanned(it)) },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .clip(RoundedCornerShape(16.dp)),
+                            )
+                        }
+                    } else {
+                        CameraDeniedFallback()
+                    }
+                    OutlinedButton(
+                        onClick = { pasteMode = true },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Outlined.ContentPaste, contentDescription = null)
+                        Text(text = " ${stringResource(R.string.scan_paste)}")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanStatus(uiState: TransactionUiState) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        when {
+            uiState.isDecoding -> Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                Text(stringResource(R.string.scan_decoding), style = MaterialTheme.typography.bodyMedium)
+            }
+
+            uiState.scanProgress > 0f -> Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                LinearProgressIndicator(
+                    progress = { uiState.scanProgress },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    stringResource(R.string.scan_progress, (uiState.scanProgress * PERCENT).toInt()),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+
+        if (uiState.scanError.isNotEmpty()) {
+            Text(
+                uiState.scanError,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PasteSection(
+    text: String,
+    onTextChange: (String) -> Unit,
+    enabled: Boolean,
+    onSubmit: () -> Unit,
+    onBackToCamera: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            stringResource(R.string.scan_paste_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            minLines = 4,
+            maxLines = 10,
+            placeholder = { Text(stringResource(R.string.scan_paste_placeholder)) },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedButton(onClick = onBackToCamera, modifier = Modifier.weight(1f)) {
+                Text(stringResource(R.string.scan_back_to_camera))
+            }
+            Button(
+                onClick = onSubmit,
+                enabled = enabled && text.isNotBlank(),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.scan_submit))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CameraDeniedFallback() {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            Icons.Outlined.PhotoCamera,
+            contentDescription = null,
+            modifier = Modifier.size(32.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            stringResource(R.string.utreexo_scan_camera_denied),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+        OutlinedButton(
+            onClick = {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+            },
+        ) {
+            Text(stringResource(R.string.open_app_settings))
+        }
+    }
+}
+
+@Composable
+private fun ContinuousCameraPreview(
+    onPayloadScanned: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lastPayload = remember { AtomicReference<String?>(null) }
+    val scanner = remember {
+        BarcodeScanning.getClient(
+            BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .build()
+        )
+    }
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            val previewView = PreviewView(ctx).apply {
+                scaleType = PreviewView.ScaleType.FILL_CENTER
+                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+            }
+            val providerFuture = ProcessCameraProvider.getInstance(ctx)
+            providerFuture.addListener({
+                val provider = providerFuture.get()
+                val preview = androidx.camera.core.Preview.Builder().build().also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+                val analysis = ImageAnalysis.Builder()
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .build()
+                    .also {
+                        it.setAnalyzer(analysisExecutor) { proxy ->
+                            processFrame(proxy, scanner) { payload ->
+                                if (lastPayload.getAndSet(payload) != payload) {
+                                    onPayloadScanned(payload)
+                                }
+                            }
+                        }
+                    }
+                try {
+                    provider.unbindAll()
+                    provider.bindToLifecycle(
+                        lifecycleOwner,
+                        CameraSelector.DEFAULT_BACK_CAMERA,
+                        preview,
+                        analysis,
+                    )
+                } catch (_: IllegalStateException) {
+                }
+            }, ContextCompat.getMainExecutor(ctx))
+            previewView
+        },
+    )
+}
+
+@androidx.annotation.OptIn(ExperimentalGetImage::class)
+private fun processFrame(
+    proxy: ImageProxy,
+    scanner: BarcodeScanner,
+    onPayload: (String) -> Unit,
+) {
+    val mediaImage = proxy.image
+    if (mediaImage == null) {
+        proxy.close()
+        return
+    }
+    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
+    scanner.process(image)
+        .addOnSuccessListener { barcodes ->
+            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
+        }
+        .addOnCompleteListener { proxy.close() }
+}
+
+private const val SHEET_HEIGHT_FRACTION = 0.92f
+private const val PERCENT = 100
+private val MAX_CONTENT_WIDTH = 520.dp

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionUiState.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.transaction
 
 import androidx.compose.runtime.Stable
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetTransactionResponse
+import com.github.jvsena42.mandacaru.domain.scan.DecodedTransaction
 
 @Stable
 data class TransactionUiState(
@@ -12,4 +13,9 @@ data class TransactionUiState(
     val broadcastResult: String = "",
     val isBroadcasting: Boolean = false,
     val errorMessage: String = "",
+    val isScannerVisible: Boolean = false,
+    val scanProgress: Float = 0f,
+    val scanError: String = "",
+    val isDecoding: Boolean = false,
+    val decodedTx: DecodedTransaction? = null,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionViewModel.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
+import com.github.jvsena42.mandacaru.domain.scan.QrTransactionScanner
+import com.github.jvsena42.mandacaru.domain.scan.ScanState
+import com.github.jvsena42.mandacaru.domain.scan.TransactionDecoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -14,7 +17,9 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 
 class TransactionViewModel(
-    private val florestaRpc: FlorestaRpc
+    private val florestaRpc: FlorestaRpc,
+    private val qrScanner: QrTransactionScanner,
+    private val transactionDecoder: TransactionDecoder,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TransactionUiState())
@@ -36,7 +41,74 @@ class TransactionViewModel(
             is TransactionAction.OnRawTxChanged -> {
                 _uiState.update { it.copy(rawTxHex = action.rawTx, broadcastResult = "") }
             }
-            TransactionAction.OnClickBroadcast -> broadcastTransaction()
+            TransactionAction.OnClickBroadcast ->
+                broadcastTransaction(_uiState.value.rawTxHex, clearInput = true)
+            TransactionAction.OnClickScan -> openScanner()
+            TransactionAction.OnDismissScanner -> closeScanner()
+            is TransactionAction.OnQrFrameScanned -> handleScannedFrame(action.payload)
+            is TransactionAction.OnScanPasteSubmitted -> handleScannedFrame(action.text)
+            TransactionAction.OnConfirmBroadcast -> {
+                val hex = _uiState.value.decodedTx?.rawHex ?: return
+                broadcastTransaction(hex, clearInput = false)
+            }
+            TransactionAction.OnDismissConfirmation -> _uiState.update { it.copy(decodedTx = null) }
+        }
+    }
+
+    private fun openScanner() {
+        qrScanner.reset()
+        _uiState.update {
+            it.copy(
+                isScannerVisible = true,
+                scanProgress = 0f,
+                scanError = "",
+                decodedTx = null,
+                broadcastResult = "",
+            )
+        }
+    }
+
+    private fun closeScanner() {
+        qrScanner.reset()
+        _uiState.update { it.copy(isScannerVisible = false, scanProgress = 0f, scanError = "") }
+    }
+
+    private fun handleScannedFrame(payload: String) {
+        if (_uiState.value.isDecoding || _uiState.value.decodedTx != null) return
+        when (val state = qrScanner.ingest(payload)) {
+            is ScanState.Idle -> Unit
+            is ScanState.InProgress ->
+                _uiState.update { it.copy(scanProgress = state.progress, scanError = "") }
+            is ScanState.Error ->
+                _uiState.update { it.copy(scanError = state.reason, scanProgress = 0f) }
+            is ScanState.Complete -> decodePayload(state)
+        }
+    }
+
+    private fun decodePayload(complete: ScanState.Complete) {
+        _uiState.update { it.copy(isDecoding = true, scanError = "") }
+        viewModelScope.launch(Dispatchers.IO) {
+            transactionDecoder.decode(complete.payload, complete.transport)
+                .onSuccess { decoded ->
+                    _uiState.update {
+                        it.copy(
+                            decodedTx = decoded,
+                            isScannerVisible = false,
+                            isDecoding = false,
+                            scanProgress = 0f,
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    Log.e(TAG, "decode error: ${error.message}", error)
+                    _uiState.update {
+                        it.copy(
+                            scanError = error.message ?: "Couldn't decode the QR code",
+                            isDecoding = false,
+                            scanProgress = 0f,
+                        )
+                    }
+                }
         }
     }
 
@@ -52,7 +124,7 @@ class TransactionViewModel(
                 return@launch
             }
 
-            if (!txId.matches(Regex("^[a-fA-F0-9]{64}$"))) {
+            if (!txId.matches(SEARCH_REGEX)) {
                 _uiState.update {
                     it.copy(isSearchLoading = false, errorMessage = "Invalid transaction ID format")
                 }
@@ -103,11 +175,11 @@ class TransactionViewModel(
         }
     }
 
-    private fun broadcastTransaction() {
-        val hex = _uiState.value.rawTxHex.trim()
+    private fun broadcastTransaction(rawHex: String, clearInput: Boolean) {
+        val hex = rawHex.trim()
         if (hex.isEmpty()) return
 
-        if (!hex.matches(Regex("^[a-fA-F0-9]+$"))) {
+        if (!hex.matches(BROADCAST_REGEX)) {
             _uiState.update { it.copy(errorMessage = "Invalid hex format") }
             return
         }
@@ -122,7 +194,8 @@ class TransactionViewModel(
                         it.copy(
                             broadcastResult = data.result,
                             isBroadcasting = false,
-                            rawTxHex = ""
+                            decodedTx = null,
+                            rawTxHex = if (clearInput) "" else it.rawTxHex,
                         )
                     }
                 }.onFailure { error ->
@@ -146,5 +219,7 @@ class TransactionViewModel(
     companion object {
         private const val TAG = "TransactionViewModel"
         private const val PERCENTAGE_MULTIPLIER = 100
+        private val SEARCH_REGEX = Regex("^[a-fA-F0-9]{64}$")
+        private val BROADCAST_REGEX = Regex("^[a-fA-F0-9]+$")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,4 +117,35 @@
     <string name="recent_blocks">Recent blocks</string>
     <string name="coming_soon">Coming soon</string>
     <string name="block_explorer_hint">Detailed block and mempool data are coming in a future update.</string>
+
+    <string name="scan_to_broadcast">Scan to broadcast</string>
+    <string name="scan_transaction_title">Scan signed transaction</string>
+    <string name="scan_transaction_hint">Point the camera at a QR from your signing device. Animated (multi-part) QR codes are supported.</string>
+    <string name="scan_progress">Receiving… %1$d%%</string>
+    <string name="scan_decoding">Decoding…</string>
+    <string name="scan_paste">Paste instead</string>
+    <string name="scan_back_to_camera">Back to camera</string>
+    <string name="scan_paste_hint">Paste a signed transaction hex, a PSBT (base64 or hex), or a ur:… string.</string>
+    <string name="scan_paste_placeholder">0200000001… / cHNidP8B… / ur:crypto-psbt/…</string>
+    <string name="scan_submit">Decode</string>
+
+    <string name="confirm_broadcast_title">Broadcast this transaction?</string>
+    <string name="confirm_decoded_from">Decoded from %1$s (%2$s)</string>
+    <string name="confirm_source_psbt">PSBT</string>
+    <string name="confirm_source_transaction">raw transaction</string>
+    <string name="confirm_transport_single">single QR</string>
+    <string name="confirm_transport_ur">animated UR</string>
+    <string name="confirm_transport_bbqr">animated BBQr</string>
+    <string name="confirm_tx_id">Transaction ID</string>
+    <string name="confirm_inputs">Inputs</string>
+    <string name="confirm_outputs">Outputs</string>
+    <string name="confirm_total_out">Total out</string>
+    <string name="confirm_fee">Fee</string>
+    <string name="confirm_fee_rate">Fee rate</string>
+    <string name="confirm_virtual_size">Virtual size</string>
+    <string name="confirm_fee_unavailable">Unavailable</string>
+    <string name="confirm_fee_unavailable_hint">A raw transaction doesn\'t include input amounts, so the fee can\'t be derived. Use a PSBT to see the fee.</string>
+    <string name="value_sats">%1$s sats</string>
+    <string name="value_sat_vb">%1$s sat/vB</string>
+    <string name="value_vbytes">%1$s vBytes</string>
 </resources>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/scan/BbqrJoinerTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/scan/BbqrJoinerTest.kt
@@ -1,0 +1,109 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+
+class BbqrJoinerTest {
+
+    @Test
+    fun `single hex part completes`() {
+        val bytes = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xFF.toByte(), 0x01, 0x02, 0x03)
+
+        val result = BbqrJoiner().addPart("B\$HP0100" + "70736274FF010203")
+
+        assertTrue(result is BbqrJoiner.Result.Complete)
+        assertArrayEquals(bytes, (result as BbqrJoiner.Result.Complete).data)
+    }
+
+    @Test
+    fun `multi-part hex concatenates by index`() {
+        val joiner = BbqrJoiner()
+
+        val first = joiner.addPart("B\$HP0200" + "70736274")
+        val second = joiner.addPart("B\$HP0201" + "FF010203")
+
+        assertEquals(BbqrJoiner.Result.InProgress(received = 1, total = 2), first)
+        assertTrue(second is BbqrJoiner.Result.Complete)
+        assertArrayEquals(
+            byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xFF.toByte(), 0x01, 0x02, 0x03),
+            (second as BbqrJoiner.Result.Complete).data,
+        )
+    }
+
+    @Test
+    fun `base32 part decodes`() {
+        val original = ByteArray(40) { (it * 3).toByte() }
+
+        val result = BbqrJoiner().addPart("B\$2P0100" + base32Encode(original))
+
+        assertTrue(result is BbqrJoiner.Result.Complete)
+        assertArrayEquals(original, (result as BbqrJoiner.Result.Complete).data)
+    }
+
+    @Test
+    fun `zlib part inflates the original bytes`() {
+        val original = ByteArray(220) { (it % 17).toByte() }
+
+        val result = BbqrJoiner().addPart("B\$ZP0100" + base32Encode(rawDeflate(original)))
+
+        assertTrue(result is BbqrJoiner.Result.Complete)
+        assertArrayEquals(original, (result as BbqrJoiner.Result.Complete).data)
+    }
+
+    @Test
+    fun `part from a different sequence is rejected`() {
+        val joiner = BbqrJoiner()
+        joiner.addPart("B\$HP0200" + "7073")
+
+        try {
+            joiner.addPart("B\$HP0300" + "6274")
+            fail("expected a mismatched-sequence error")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("different sequence") == true)
+        }
+    }
+
+    private fun rawDeflate(data: ByteArray): ByteArray {
+        val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
+        deflater.setInput(data)
+        deflater.finish()
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(1024)
+        while (!deflater.finished()) {
+            output.write(buffer, 0, deflater.deflate(buffer))
+        }
+        deflater.end()
+        return output.toByteArray()
+    }
+
+    private fun base32Encode(data: ByteArray): String {
+        val builder = StringBuilder()
+        var buffer = 0
+        var bits = 0
+        for (byte in data) {
+            buffer = (buffer shl BITS_PER_BYTE) or (byte.toInt() and BYTE_MASK)
+            bits += BITS_PER_BYTE
+            while (bits >= BITS_PER_CHAR) {
+                bits -= BITS_PER_CHAR
+                builder.append(ALPHABET[(buffer ushr bits) and CHAR_MASK])
+            }
+        }
+        if (bits > 0) {
+            builder.append(ALPHABET[(buffer shl (BITS_PER_CHAR - bits)) and CHAR_MASK])
+        }
+        return builder.toString()
+    }
+
+    private companion object {
+        const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        const val BITS_PER_BYTE = 8
+        const val BITS_PER_CHAR = 5
+        const val BYTE_MASK = 0xFF
+        const val CHAR_MASK = 0x1F
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScannerTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScannerTest.kt
@@ -1,0 +1,104 @@
+package com.github.jvsena42.mandacaru.domain.scan
+
+import com.sparrowwallet.hummingbird.UR
+import com.sparrowwallet.hummingbird.UREncoder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+class QrTransactionScannerTest {
+
+    private val scanner = DefaultQrTransactionScanner()
+
+    @Test
+    fun `single hex frame completes with decoded bytes`() {
+        val bytes = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x01)
+
+        val state = scanner.ingest("0200000001")
+
+        assertTrue(state is ScanState.Complete)
+        state as ScanState.Complete
+        assertArrayEquals(bytes, state.payload)
+        assertEquals(ScanTransport.SINGLE, state.transport)
+    }
+
+    @Test
+    fun `single base64 psbt frame completes with decoded bytes`() {
+        val bytes = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xFF.toByte(), 0x01, 0x00)
+        val base64 = Base64.getEncoder().encodeToString(bytes)
+
+        val state = scanner.ingest(base64)
+
+        assertTrue(state is ScanState.Complete)
+        state as ScanState.Complete
+        assertArrayEquals(bytes, state.payload)
+        assertEquals(ScanTransport.SINGLE, state.transport)
+    }
+
+    @Test
+    fun `unrecognized content returns an error`() {
+        val state = scanner.ingest("not a valid payload!")
+
+        assertTrue(state is ScanState.Error)
+    }
+
+    @Test
+    fun `blank input is idle`() {
+        assertTrue(scanner.ingest("   ") is ScanState.Idle)
+    }
+
+    @Test
+    fun `single bbqr part completes with bbqr transport`() {
+        val bytes = byteArrayOf(0x70, 0x73, 0x62, 0x74, 0xFF.toByte())
+
+        val state = scanner.ingest("B\$HP0100" + "70736274FF")
+
+        assertTrue(state is ScanState.Complete)
+        state as ScanState.Complete
+        assertEquals(ScanTransport.BBQR, state.transport)
+        assertArrayEquals(bytes, state.payload)
+    }
+
+    @Test
+    fun `multi-part ur reassembles into the original bytes`() {
+        val original = ByteArray(180) { (it * 7).toByte() }
+        val encoder = UREncoder(UR.fromBytes(original), FRAGMENT_LEN, MIN_FRAGMENT_LEN, 0L)
+
+        var sawProgress = false
+        var state: ScanState = ScanState.Idle
+        var guard = 0
+        while (state !is ScanState.Complete && guard < MAX_PARTS) {
+            state = scanner.ingest(encoder.nextPart())
+            if (state is ScanState.InProgress) sawProgress = true
+            guard++
+        }
+
+        assertTrue("expected progress before completion", sawProgress)
+        assertTrue(state is ScanState.Complete)
+        state as ScanState.Complete
+        assertArrayEquals(original, state.payload)
+        assertEquals(ScanTransport.UR, state.transport)
+    }
+
+    @Test
+    fun `reset clears partial ur state`() {
+        val original = ByteArray(180) { it.toByte() }
+        val encoder = UREncoder(UR.fromBytes(original), FRAGMENT_LEN, MIN_FRAGMENT_LEN, 0L)
+
+        scanner.ingest(encoder.nextPart())
+        scanner.reset()
+
+        // After reset, a single-frame hex is treated independently rather than as a UR fragment.
+        val state = scanner.ingest("0200000001")
+        assertTrue(state is ScanState.Complete)
+        assertEquals(ScanTransport.SINGLE, (state as ScanState.Complete).transport)
+    }
+
+    private companion object {
+        const val FRAGMENT_LEN = 30
+        const val MIN_FRAGMENT_LEN = 10
+        const val MAX_PARTS = 200
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ camerax = "1.6.1"
 mlkit-barcode = "17.3.0"
 coreSplashscreen = "1.0.1"
 orgJson = "20240303"
+hummingbird = "1.7.4"
+bdk = "2.3.1"
 
 [libraries]
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
@@ -66,6 +68,8 @@ androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", versi
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkit-barcode" }
 org-json = { module = "org.json:json", version.ref = "orgJson" }
+hummingbird = { module = "com.sparrowwallet:hummingbird", version.ref = "hummingbird" }
+bdk-android = { module = "org.bitcoindevkit:bdk-android", version.ref = "bdk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Implements [#64](https://github.com/jvsena42/mandacaru/issues/64): scan a QR code containing a signed transaction from an airgapped wallet (SeedSigner, Krux, Coldcard, Specter DIY, Keystone), review the decoded details, and broadcast it through the on-device Floresta node.

Entry point is a **"Scan to broadcast"** button on the Transactions screen's broadcast card → scanner sheet → decoded confirmation sheet → existing `sendRawTransaction`. Phone and tablet adaptive.

## Supported encodings

- **Single-frame**: raw signed tx hex, or PSBT (base64 / hex)
- **Animated UR / BCUR**: `ur:bytes`, `ur:crypto-psbt` (SeedSigner, Krux, Specter, Keystone)
- **Animated BBQr**: Coldcard

## Decode stack (Kotlin-only, no Rust build-chain changes)

| Concern | How |
|---|---|
| UR / BCUR | `com.sparrowwallet:hummingbird` (pure Java) |
| BBQr | hand-rolled pure-Kotlin `BbqrJoiner` + `Base32` (no native lib) |
| PSBT + raw tx parse / finalize-extract / fee | `org.bitcoindevkit:bdk-android` |

## Why BBQr is hand-rolled instead of `org.bitcoinppl:bbqr-android`

`bbqr-android:0.3.1`'s prebuilt `libbbqrffi.so` has **4 KB-aligned** LOAD segments (`0x1000`), which fails to load on Android 15+ 16 KB-page devices — the exact regression fixed in #89 / commit `22b35e6` (bdk + floresta libs are correctly `0x4000`). There's no fixed upstream release, and prebuilt `.so` alignment can't be patched after the fact, so BBQr is implemented in pure Kotlin (no native lib → 16 KB-safe). Reported upstream: [bitcoinppl/bbqr-ffi#4](https://github.com/bitcoinppl/bbqr-ffi/issues/4).

## Known limitations (surfaced in the UI)

- **Fee / fee-rate** shows only for **PSBT** input — a raw signed tx doesn't carry input amounts, and the utreexo node has no `decoderawtransaction`/prevout lookup.
- The **PSBT must already be finalized** (bdk `extractTx` doesn't finalize from partial signatures); the user is told to finalize on their signer otherwise.

## Testing

- `./gradlew testDebugUnitTest` — 12 new unit tests pass (`QrTransactionScannerTest`, `BbqrJoinerTest`: single/multi-part hex, base32, zlib, UR round-trip, sequence-mismatch, format detection).
- `./gradlew detekt lintDebug assembleDebug` — all pass; APK verified to no longer bundle `libbbqrffi.so` and to keep `libbdkffi.so`/`libuniffi_floresta.so` 16 KB-aligned.
- bdk/BBQr/UR end-to-end QR scanning needs a device (manual): single-frame hex/PSBT, animated UR, animated BBQr, on signet/regtest.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
