### PR TITLE
feat: in-app update check, download, and APK naming

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,13 +18,13 @@ Release process for Mandacaru. Version: $ARGUMENTS
 
 3. **Bump version**:
    - Extract the numeric version (strip the `v` prefix, e.g. `v0.2.0` -> `0.2.0`).
-   - Update `versionName` in `app/build.gradle.kts` to the new version.
+   - Update the `appVersionName` top-level `val` in `app/build.gradle.kts` to the new numeric version. This single `val` feeds both `defaultConfig.versionName` and the APK output name, so it is the only place to change.
    - Increment `versionCode` by 1 in `app/build.gradle.kts`.
    - Commit the version bump: `chore: bump version to <version>`.
 
 4. **Build signed APK**:
    - Run `./gradlew clean assembleRelease`.
-   - Verify the APK exists at `app/build/outputs/apk/release/app-release.apk`.
+   - Verify the APK exists at `app/build/outputs/apk/release/Mandacaru-<numeric_version>.apk` (the output is named `Mandacaru-$appVersionName.apk`, e.g. `Mandacaru-0.2.0.apk`).
 
 5. **Create git tag**:
    - Create annotated tag: `git tag -a <version> -m "Release <version>"`.
@@ -38,7 +38,7 @@ Release process for Mandacaru. Version: $ARGUMENTS
    - Show the changelog to the user for approval before proceeding.
 
 7. **Create GitHub release**:
-   - Use `gh release create <version>` with the signed APK attached.
+   - Use `gh release create <version>` with the signed APK (`Mandacaru-<numeric_version>.apk`) attached.
    - Title: `Mandacaru <version>`.
    - Use the approved changelog as the release body (pass via `--notes`).
    - Mark as latest release.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,12 @@
+import com.android.build.api.variant.impl.VariantOutputImpl
 import java.util.Properties
 
 val localProperties = Properties().apply {
     val file = rootProject.file("local.properties")
     if (file.exists()) load(file.inputStream())
 }
+
+val appVersionName = "0.10.3"
 
 plugins {
     alias(libs.plugins.android.application)
@@ -20,7 +23,7 @@ android {
         minSdk = 29
         targetSdk = 36
         versionCode = 21
-        versionName = "0.10.3"
+        versionName = appVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -64,6 +67,16 @@ android {
     }
     lint {
         lintConfig = file("lint.xml")
+    }
+}
+
+androidComponents {
+    onVariants { variant ->
+        // AGP 9 removed the legacy applicationVariants output API; the APK file
+        // name is now set through the internal VariantOutputImpl.
+        variant.outputs.forEach { output ->
+            (output as? VariantOutputImpl)?.outputFileName?.set("Mandacaru-$appVersionName.apk")
+        }
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
@@ -6,11 +6,14 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import com.github.jvsena42.mandacaru.data.AppUpdateRepository
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.data.PreferencesDataSourceImpl
 import com.github.jvsena42.mandacaru.data.floresta.FlorestaDaemonImpl
 import com.github.jvsena42.mandacaru.data.floresta.FlorestaRpcImpl
+import com.github.jvsena42.mandacaru.data.update.AppUpdateDownloader
+import com.github.jvsena42.mandacaru.data.update.AppUpdateRepositoryImpl
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
@@ -19,6 +22,7 @@ import com.github.jvsena42.mandacaru.domain.scan.DefaultQrTransactionScanner
 import com.github.jvsena42.mandacaru.domain.scan.QrTransactionScanner
 import com.github.jvsena42.mandacaru.domain.scan.TransactionDecoder
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.BlockchainViewModel
+import com.github.jvsena42.mandacaru.presentation.ui.screens.main.MainViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.NodeViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.transaction.TransactionViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.settings.SettingsViewModel
@@ -59,7 +63,16 @@ val presentationModule = module {
             preferencesDataSource = get(),
         )
     }
-    viewModel { SettingsViewModel(florestaRpc = get(), preferencesDataSource = get(), context = androidContext()) }
+    viewModel {
+        SettingsViewModel(
+            florestaRpc = get(),
+            preferencesDataSource = get(),
+            appUpdateRepository = get(),
+            appUpdateDownloader = get(),
+            context = androidContext(),
+        )
+    }
+    viewModel { MainViewModel(appUpdateRepository = get()) }
     viewModel {
         TransactionViewModel(
             florestaRpc = get(),
@@ -78,6 +91,10 @@ val dataModule = module {
         )
     }
     single<FlorestaRpc> { FlorestaRpcImpl(gson = Gson(), preferencesDataSource = get()) }
+    single<AppUpdateRepository> {
+        AppUpdateRepositoryImpl(gson = Gson(), preferencesDataSource = get())
+    }
+    single { AppUpdateDownloader(context = androidContext()) }
     single<PreferencesDataSource> {
         PreferencesDataSourceImpl(
             dataStore = androidContext().florestaDataStore

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/AppUpdateRepository.kt
@@ -1,0 +1,12 @@
+package com.github.jvsena42.mandacaru.data
+
+import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
+import kotlinx.coroutines.flow.StateFlow
+
+interface AppUpdateRepository {
+    val updateStatus: StateFlow<UpdateStatus>
+
+    suspend fun refresh(force: Boolean = false)
+
+    suspend fun markUpdateSeen()
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
@@ -8,5 +8,9 @@ enum class PreferenceKeys(val dataStoreKey: Preferences.Key<String>) {
     CURRENT_RPC_PORT(stringPreferencesKey("CURRENT_RPC_PORT")),
     PENDING_UTREEXO_SNAPSHOT(stringPreferencesKey("PENDING_UTREEXO_SNAPSHOT")),
     WALLET_BIRTHDAY_YEAR(stringPreferencesKey("WALLET_BIRTHDAY_YEAR")),
-    WALLET_NEEDS_RESCAN(stringPreferencesKey("WALLET_NEEDS_RESCAN"))
+    WALLET_NEEDS_RESCAN(stringPreferencesKey("WALLET_NEEDS_RESCAN")),
+    UPDATE_LAST_CHECK(stringPreferencesKey("UPDATE_LAST_CHECK")),
+    UPDATE_LATEST_VERSION(stringPreferencesKey("UPDATE_LATEST_VERSION")),
+    UPDATE_LATEST_APK_URL(stringPreferencesKey("UPDATE_LATEST_APK_URL")),
+    UPDATE_SEEN_VERSION(stringPreferencesKey("UPDATE_SEEN_VERSION"))
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateDownloader.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateDownloader.kt
@@ -1,0 +1,58 @@
+package com.github.jvsena42.mandacaru.data.update
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.Uri
+import android.os.Environment
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+
+class AppUpdateDownloader(private val context: Context) {
+
+    fun canInstall(): Boolean = context.packageManager.canRequestPackageInstalls()
+
+    fun enqueue(url: String, fileName: String) {
+        val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val request = DownloadManager.Request(url.toUri())
+            .setTitle(fileName)
+            .setMimeType(APK_MIME_TYPE)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
+        val downloadId = downloadManager.enqueue(request)
+        registerCompletionReceiver(downloadManager, downloadId)
+    }
+
+    private fun registerCompletionReceiver(downloadManager: DownloadManager, downloadId: Long) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                val completedId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
+                if (completedId != downloadId) return
+                context.unregisterReceiver(this)
+                downloadManager.getUriForDownloadedFile(downloadId)
+                    ?.let { uri -> launchInstaller(context, uri) }
+            }
+        }
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED,
+        )
+    }
+
+    private fun launchInstaller(context: Context, uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, APK_MIME_TYPE)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    companion object {
+        private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateRepositoryImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateRepositoryImpl.kt
@@ -1,0 +1,130 @@
+package com.github.jvsena42.mandacaru.data.update
+
+import android.util.Log
+import com.github.jvsena42.mandacaru.BuildConfig
+import com.github.jvsena42.mandacaru.data.AppUpdateRepository
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
+import com.github.jvsena42.mandacaru.domain.model.github.GithubRelease
+import com.github.jvsena42.mandacaru.domain.update.VersionComparator
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+class AppUpdateRepositoryImpl(
+    private val gson: Gson,
+    private val preferencesDataSource: PreferencesDataSource,
+) : AppUpdateRepository {
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private val _updateStatus = MutableStateFlow(UpdateStatus())
+    override val updateStatus = _updateStatus.asStateFlow()
+
+    override suspend fun refresh(force: Boolean) = withContext(Dispatchers.IO) {
+        emitCachedStatus()
+        if (!force && !isCheckDue()) return@withContext
+        _updateStatus.update { it.copy(isChecking = true, checkFailed = false) }
+        runCatching { fetchLatestRelease() }
+            .onSuccess { release -> applyRelease(release) }
+            .onFailure { error ->
+                Log.w(TAG, "refresh: failed to check for updates", error)
+                _updateStatus.update { it.copy(isChecking = false, checkFailed = true) }
+            }
+        Unit
+    }
+
+    override suspend fun markUpdateSeen() {
+        val latest = _updateStatus.value.latestVersion
+        if (latest.isEmpty()) return
+        preferencesDataSource.setString(PreferenceKeys.UPDATE_SEEN_VERSION, latest)
+        _updateStatus.update { it.copy(isBadgeVisible = false) }
+    }
+
+    private suspend fun emitCachedStatus() {
+        val latest = preferencesDataSource.getString(PreferenceKeys.UPDATE_LATEST_VERSION, "")
+        if (latest.isEmpty()) return
+        val apkUrl = preferencesDataSource.getString(PreferenceKeys.UPDATE_LATEST_APK_URL, "")
+        val seen = preferencesDataSource.getString(PreferenceKeys.UPDATE_SEEN_VERSION, "")
+        val isUpdate = VersionComparator.isNewer(latest, BuildConfig.VERSION_NAME)
+        _updateStatus.update {
+            it.copy(
+                isUpdateAvailable = isUpdate,
+                latestVersion = latest,
+                apkDownloadUrl = apkUrl.ifEmpty { null },
+                isBadgeVisible = isUpdate && latest != seen,
+            )
+        }
+    }
+
+    private suspend fun applyRelease(release: GithubRelease) {
+        val latest = release.tagName.orEmpty().removePrefix("v").removePrefix("V")
+        val apkUrl = release.assets
+            .firstOrNull { it.name?.endsWith(APK_SUFFIX) == true }
+            ?.browserDownloadUrl
+        val isUpdate = latest.isNotEmpty() &&
+            VersionComparator.isNewer(latest, BuildConfig.VERSION_NAME)
+        val seen = preferencesDataSource.getString(PreferenceKeys.UPDATE_SEEN_VERSION, "")
+
+        preferencesDataSource.setString(PreferenceKeys.UPDATE_LATEST_VERSION, latest)
+        preferencesDataSource.setString(PreferenceKeys.UPDATE_LATEST_APK_URL, apkUrl.orEmpty())
+        preferencesDataSource.setString(
+            PreferenceKeys.UPDATE_LAST_CHECK,
+            System.currentTimeMillis().toString(),
+        )
+
+        _updateStatus.update {
+            it.copy(
+                isUpdateAvailable = isUpdate,
+                latestVersion = latest,
+                apkDownloadUrl = apkUrl,
+                releasePageUrl = release.htmlUrl ?: UpdateStatus.RELEASES_URL,
+                isChecking = false,
+                checkFailed = false,
+                isBadgeVisible = isUpdate && latest != seen,
+            )
+        }
+    }
+
+    private fun fetchLatestRelease(): GithubRelease {
+        val request = Request.Builder()
+            .url(LATEST_RELEASE_URL)
+            .header("Accept", "application/vnd.github+json")
+            .build()
+        client.newCall(request).execute().use { response ->
+            require(response.isSuccessful) { "Unexpected response ${response.code}" }
+            val body = response.body.string()
+            return gson.fromJson(body, GithubRelease::class.java)
+        }
+    }
+
+    private suspend fun isCheckDue(): Boolean {
+        val lastCheck = preferencesDataSource
+            .getString(PreferenceKeys.UPDATE_LAST_CHECK, "")
+            .toLongOrNull() ?: 0L
+        return System.currentTimeMillis() - lastCheck >= CHECK_INTERVAL_MS
+    }
+
+    companion object {
+        private const val TAG = "AppUpdateRepository"
+        private const val APK_SUFFIX = ".apk"
+        private const val CONNECT_TIMEOUT_SECONDS = 10L
+        private const val READ_TIMEOUT_SECONDS = 30L
+        private const val CHECK_INTERVAL_HOURS = 24L
+        private val CHECK_INTERVAL_MS = TimeUnit.HOURS.toMillis(CHECK_INTERVAL_HOURS)
+        private const val LATEST_RELEASE_URL =
+            "https://api.github.com/repos/jvsena42/mandacaru/releases/latest"
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/UpdateStatus.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/UpdateStatus.kt
@@ -1,0 +1,15 @@
+package com.github.jvsena42.mandacaru.domain.model
+
+data class UpdateStatus(
+    val isUpdateAvailable: Boolean = false,
+    val latestVersion: String = "",
+    val apkDownloadUrl: String? = null,
+    val releasePageUrl: String = RELEASES_URL,
+    val isChecking: Boolean = false,
+    val checkFailed: Boolean = false,
+    val isBadgeVisible: Boolean = false,
+) {
+    companion object {
+        const val RELEASES_URL = "https://github.com/jvsena42/mandacaru/releases/latest"
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/github/GithubRelease.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/github/GithubRelease.kt
@@ -1,0 +1,14 @@
+package com.github.jvsena42.mandacaru.domain.model.github
+
+import com.google.gson.annotations.SerializedName
+
+data class GithubRelease(
+    @SerializedName("tag_name") val tagName: String?,
+    @SerializedName("html_url") val htmlUrl: String?,
+    val assets: List<GithubAsset> = emptyList(),
+)
+
+data class GithubAsset(
+    val name: String?,
+    @SerializedName("browser_download_url") val browserDownloadUrl: String?,
+)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/update/VersionComparator.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/update/VersionComparator.kt
@@ -1,0 +1,23 @@
+package com.github.jvsena42.mandacaru.domain.update
+
+object VersionComparator {
+
+    fun isNewer(remote: String, current: String): Boolean {
+        val remoteParts = parse(remote)
+        val currentParts = parse(current)
+        val size = maxOf(remoteParts.size, currentParts.size)
+        for (index in 0 until size) {
+            val remoteValue = remoteParts.getOrElse(index) { 0 }
+            val currentValue = currentParts.getOrElse(index) { 0 }
+            if (remoteValue != currentValue) return remoteValue > currentValue
+        }
+        return false
+    }
+
+    private fun parse(version: String): List<Int> =
+        version.trim()
+            .removePrefix("v")
+            .removePrefix("V")
+            .split(".")
+            .map { part -> part.takeWhile(Char::isDigit).toIntOrNull() ?: 0 }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -42,6 +44,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,6 +73,7 @@ import com.github.jvsena42.mandacaru.presentation.utils.restartApplication
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import org.koin.androidx.compose.KoinAndroidContext
+import org.koin.androidx.compose.koinViewModel
 
 class MainActivity : ComponentActivity() {
 
@@ -175,8 +179,10 @@ private fun MandacaruRoot(
     restartApplication: () -> Unit,
     requestNotificationPermission: () -> Unit,
     hasNotificationPermission: Boolean,
+    mainViewModel: MainViewModel = koinViewModel(),
 ) {
     var showSplash by remember { mutableStateOf(showSplashOnStart) }
+    val isUpdateBadgeVisible by mainViewModel.isUpdateBadgeVisible.collectAsState()
     LaunchedEffect(Unit) {
         if (showSplash) {
             delay(SPLASH_DURATION_MS)
@@ -191,6 +197,7 @@ private fun MandacaruRoot(
             restartApplication = restartApplication,
             requestNotificationPermission = requestNotificationPermission,
             hasNotificationPermission = hasNotificationPermission,
+            isSettingsBadgeVisible = isUpdateBadgeVisible,
         )
         AnimatedVisibility(
             visible = showSplash,
@@ -210,7 +217,8 @@ private fun MainScreen(
     restartApplication: () -> Unit,
     modifier: Modifier = Modifier,
     requestNotificationPermission: () -> Unit = {},
-    hasNotificationPermission: Boolean = true
+    hasNotificationPermission: Boolean = true,
+    isSettingsBadgeVisible: Boolean = false,
 ) {
     val pages = Destinations.entries
     val pagerState = rememberPagerState(
@@ -258,6 +266,7 @@ private fun MainScreen(
                     pages = pages,
                     selectedIndex = pagerState.currentPage,
                     onSelect = onSelectDestination,
+                    isSettingsBadgeVisible = isSettingsBadgeVisible,
                 )
             }
         }
@@ -273,6 +282,7 @@ private fun MainScreen(
                     pages = pages,
                     selectedIndex = pagerState.currentPage,
                     onSelect = onSelectDestination,
+                    isSettingsBadgeVisible = isSettingsBadgeVisible,
                 )
             }
             HorizontalPager(
@@ -305,6 +315,7 @@ private fun AppNavigationBar(
     pages: List<Destinations>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
+    isSettingsBadgeVisible: Boolean,
 ) {
     NavigationBar(
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -323,7 +334,7 @@ private fun AppNavigationBar(
                 selected = selected,
                 onClick = { onSelect(index) },
                 label = { DestinationLabel(destination, selected) },
-                icon = { DestinationIcon(destination) },
+                icon = { DestinationIcon(destination, showBadge(destination, isSettingsBadgeVisible)) },
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = MaterialTheme.colorScheme.primary,
                     selectedTextColor = MaterialTheme.colorScheme.primary,
@@ -341,6 +352,7 @@ private fun AppNavigationRail(
     pages: List<Destinations>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
+    isSettingsBadgeVisible: Boolean,
 ) {
     NavigationRail(
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -353,7 +365,7 @@ private fun AppNavigationRail(
                 selected = selected,
                 onClick = { onSelect(index) },
                 label = { DestinationLabel(destination, selected) },
-                icon = { DestinationIcon(destination) },
+                icon = { DestinationIcon(destination, showBadge(destination, isSettingsBadgeVisible)) },
                 colors = NavigationRailItemDefaults.colors(
                     selectedIconColor = MaterialTheme.colorScheme.primary,
                     selectedTextColor = MaterialTheme.colorScheme.primary,
@@ -379,12 +391,24 @@ private fun DestinationLabel(destination: Destinations, selected: Boolean) {
 }
 
 @Composable
-private fun DestinationIcon(destination: Destinations) {
-    Icon(
-        painter = painterResource(destination.icon),
-        contentDescription = destination.label
-    )
+private fun DestinationIcon(destination: Destinations, showBadge: Boolean = false) {
+    if (showBadge) {
+        BadgedBox(badge = { Badge() }) {
+            Icon(
+                painter = painterResource(destination.icon),
+                contentDescription = destination.label
+            )
+        }
+    } else {
+        Icon(
+            painter = painterResource(destination.icon),
+            contentDescription = destination.label
+        )
+    }
 }
+
+private fun showBadge(destination: Destinations, isSettingsBadgeVisible: Boolean): Boolean =
+    destination == Destinations.SETTINGS && isSettingsBadgeVisible
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainViewModel.kt
@@ -1,0 +1,22 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.jvsena42.mandacaru.data.AppUpdateRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class MainViewModel(
+    private val appUpdateRepository: AppUpdateRepository,
+) : ViewModel() {
+
+    val isUpdateBadgeVisible = appUpdateRepository.updateStatus
+        .map { it.isBadgeVisible }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    init {
+        viewModelScope.launch { appUpdateRepository.refresh() }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -1,6 +1,10 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 
 import android.content.Intent
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -39,6 +43,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.NetworkCheck
@@ -95,6 +100,7 @@ import com.florestad.Network
 import com.github.jvsena42.mandacaru.BuildConfig
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.Constants
+import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
 import com.github.jvsena42.mandacaru.presentation.ui.components.ExpandableHeader
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
@@ -113,7 +119,13 @@ fun ScreenSettings(
     val uiState by viewModel.uiState.collectAsState()
     val currentRestartApplication by rememberUpdatedState(restartApplication)
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val shareLogsTitle = stringResource(R.string.share_logs)
+    val installPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        viewModel.onAction(SettingsAction.OnClickDownloadUpdate)
+    }
     ScreenSettings(
         uiState = uiState,
         onAction = viewModel::onAction,
@@ -135,6 +147,15 @@ fun ScreenSettings(
                         Intent.createChooser(shareIntent, shareLogsTitle)
                     )
                 }
+                is SettingsEvents.RequestInstallPermission -> {
+                    installPermissionLauncher.launch(
+                        Intent(
+                            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                            "package:${context.packageName}".toUri()
+                        )
+                    )
+                }
+                is SettingsEvents.OpenReleasePage -> uriHandler.openUri(event.url)
             }
         }
     }
@@ -748,15 +769,15 @@ private fun ScreenSettings(
                                 }
                             )
 
-                            Spacer(modifier = Modifier.height(12.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
 
-                            Text(
-                                text = stringResource(R.string.check_for_updates),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.clickable {
-                                    uriHandler.openUri("https://github.com/jvsena42/mandacaru/releases/latest")
-                                }
+                            HorizontalDivider()
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            UpdateRow(
+                                updateStatus = uiState.updateStatus,
+                                onAction = onAction,
                             )
                         }
                     }
@@ -867,6 +888,73 @@ private fun BirthdayRestartConfirmDialog(
             }
         },
     )
+}
+
+@Composable
+private fun UpdateRow(
+    updateStatus: UpdateStatus,
+    onAction: (SettingsAction) -> Unit,
+) {
+    val uriHandler = LocalUriHandler.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        when {
+            updateStatus.isChecking -> {
+                Text(
+                    text = stringResource(R.string.checking_for_updates),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            updateStatus.isUpdateAvailable -> {
+                Text(
+                    text = stringResource(R.string.update_available),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.latest_version, updateStatus.latestVersion),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = { onAction(SettingsAction.OnClickDownloadUpdate) },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Icon(
+                        Icons.Outlined.Download,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(stringResource(R.string.download_update))
+                }
+            }
+
+            updateStatus.checkFailed -> {
+                Text(
+                    text = stringResource(R.string.check_for_updates),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable {
+                        uriHandler.openUri(updateStatus.releasePageUrl)
+                    }
+                )
+            }
+
+            else -> {
+                Text(
+                    text = stringResource(R.string.up_to_date),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -16,6 +16,7 @@ sealed interface SettingsAction {
     object ToggleAboutExpanded: SettingsAction
     object ToggleDonateExpanded: SettingsAction
     object OnClickExportLogs: SettingsAction
+    object OnClickDownloadUpdate: SettingsAction
     object ToggleBirthdayExpanded: SettingsAction
     object OnClickChangeBirthdayYear: SettingsAction
     data class OnBirthdayYearSelected(val year: Int): SettingsAction

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
@@ -4,4 +4,6 @@ sealed interface SettingsEvents {
     data object OnNetworkChanged : SettingsEvents
     data object OnBirthdayChanged : SettingsEvents
     data class OnExportLogs(val uri: android.net.Uri) : SettingsEvents
+    data object RequestInstallPermission : SettingsEvents
+    data class OpenReleasePage(val url: String) : SettingsEvents
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 
 import androidx.compose.runtime.Stable
 import com.florestad.Network
+import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
 
 
@@ -26,4 +27,5 @@ data class SettingsUiState(
     val isBirthdayExpanded: Boolean = false,
     val isBirthdayPickerOpen: Boolean = false,
     val pendingBirthdayYear: Int? = null,
+    val updateStatus: UpdateStatus = UpdateStatus(),
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -6,9 +6,11 @@ import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.jvsena42.mandacaru.data.AppUpdateRepository
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.data.update.AppUpdateDownloader
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
@@ -37,6 +39,8 @@ import com.florestad.Network as FlorestaNetwork
 class SettingsViewModel(
     private val florestaRpc: FlorestaRpc,
     private val preferencesDataSource: PreferencesDataSource,
+    private val appUpdateRepository: AppUpdateRepository,
+    private val appUpdateDownloader: AppUpdateDownloader,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel(), EventFlow<SettingsEvents> by EventFlowImpl() {
 
@@ -63,6 +67,16 @@ class SettingsViewModel(
             updateElectrumAddress()
         }
         getDescriptors()
+        observeUpdateStatus()
+    }
+
+    private fun observeUpdateStatus() {
+        viewModelScope.launch { appUpdateRepository.refresh() }
+        viewModelScope.launch {
+            appUpdateRepository.updateStatus.collect { status ->
+                _uiState.update { it.copy(updateStatus = status) }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -105,9 +119,9 @@ class SettingsViewModel(
                 it.copy(isNodeExpanded = !it.isNodeExpanded)
             }
 
-            SettingsAction.ToggleAboutExpanded -> _uiState.update {
-                it.copy(isAboutExpanded = !it.isAboutExpanded)
-            }
+            SettingsAction.ToggleAboutExpanded -> toggleAboutExpanded()
+
+            SettingsAction.OnClickDownloadUpdate -> downloadUpdate()
 
             SettingsAction.ToggleDonateExpanded -> _uiState.update {
                 it.copy(isDonateExpanded = !it.isDonateExpanded)
@@ -137,6 +151,28 @@ class SettingsViewModel(
 
             SettingsAction.OnConfirmBirthdayRestart -> applyBirthdayYearAndRestart()
         }
+    }
+
+    private fun toggleAboutExpanded() {
+        val willExpand = !_uiState.value.isAboutExpanded
+        _uiState.update { it.copy(isAboutExpanded = willExpand) }
+        if (willExpand) {
+            viewModelScope.launch { appUpdateRepository.markUpdateSeen() }
+        }
+    }
+
+    private fun downloadUpdate() {
+        val status = _uiState.value.updateStatus
+        val url = status.apkDownloadUrl
+        if (url == null) {
+            viewModelScope.sendEvent(SettingsEvents.OpenReleasePage(status.releasePageUrl))
+            return
+        }
+        if (!appUpdateDownloader.canInstall()) {
+            viewModelScope.sendEvent(SettingsEvents.RequestInstallPermission)
+            return
+        }
+        appUpdateDownloader.enqueue(url, "Mandacaru-${status.latestVersion}.apk")
     }
 
     private fun applyBirthdayYearAndRestart() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,11 @@
     <string name="suggestions_and_bugs">Suggestions and bugs</string>
     <string name="license">License</string>
     <string name="check_for_updates">Check for updates</string>
+    <string name="checking_for_updates">Checking for updates…</string>
+    <string name="update_available">Update available</string>
+    <string name="latest_version">Latest: %1$s</string>
+    <string name="download_update">Download update</string>
+    <string name="up_to_date">You\'re on the latest version</string>
     <string name="donate">Donate</string>
     <string name="lightning_address">Lightning Address</string>
     <string name="lightning_address_copied">Lightning address copied to clipboard</string>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/update/VersionComparatorTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/update/VersionComparatorTest.kt
@@ -1,0 +1,50 @@
+package com.github.jvsena42.mandacaru.domain.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VersionComparatorTest {
+
+    @Test
+    fun `newer patch is detected`() {
+        assertTrue(VersionComparator.isNewer("0.10.4", "0.10.3"))
+    }
+
+    @Test
+    fun `newer minor is detected`() {
+        assertTrue(VersionComparator.isNewer("0.11.0", "0.10.9"))
+    }
+
+    @Test
+    fun `newer major is detected`() {
+        assertTrue(VersionComparator.isNewer("1.0.0", "0.99.99"))
+    }
+
+    @Test
+    fun `equal versions are not newer`() {
+        assertFalse(VersionComparator.isNewer("0.10.3", "0.10.3"))
+    }
+
+    @Test
+    fun `older version is not newer`() {
+        assertFalse(VersionComparator.isNewer("0.10.2", "0.10.3"))
+    }
+
+    @Test
+    fun `leading v prefix is ignored`() {
+        assertTrue(VersionComparator.isNewer("v0.10.4", "0.10.3"))
+        assertFalse(VersionComparator.isNewer("v0.10.3", "0.10.3"))
+    }
+
+    @Test
+    fun `different segment counts compare correctly`() {
+        assertTrue(VersionComparator.isNewer("0.10.3.1", "0.10.3"))
+        assertFalse(VersionComparator.isNewer("0.10", "0.10.0"))
+    }
+
+    @Test
+    fun `non numeric suffixes are tolerated`() {
+        assertTrue(VersionComparator.isNewer("0.11.0-rc1", "0.10.3"))
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the static "Check for updates" link in Settings → About with a real in-app update flow: the app now compares its installed version against the latest GitHub release and lets the user download/install the update directly.

All surfaces read from a single `AppUpdateRepository` (Koin singleton) so the nav badge and the About section never disagree.

## Changes

- **Version check** — `AppUpdateRepositoryImpl` fetches `api.github.com/repos/jvsena42/mandacaru/releases/latest`, compares `tag_name` against `BuildConfig.VERSION_NAME` via a pure `VersionComparator`, and is **rate-limited to once/24h** with cached results that survive process restarts (anti-spam).
- **Settings nav badge** — a small `MainViewModel` exposes `isUpdateBadgeVisible`; a Material3 `Badge` is shown on the Settings item in **both** the phone `NavigationBar` and the tablet `NavigationRail`. It **auto-dismisses** once the About section is opened (`markUpdateSeen()` persists the seen version) and only returns for a strictly newer release. Passive only — no snackbars/dialogs/notifications.
- **About section** — shows checking / "Update available + Latest: X" with a **Download update** button / a fallback link on failure / "You're on the latest version".
- **Download + install** — `AppUpdateDownloader` uses Android `DownloadManager` → system installer (adds `REQUEST_INSTALL_PACKAGES`). If install-from-unknown-sources isn't granted, the UI opens that settings screen and retries the download on return. Falls back to opening the release page when a release has no `.apk` asset.
- **APK naming** — output is renamed to `Mandacaru-<version>.apk`. AGP 9 removed the legacy `applicationVariants` API, so this uses the new `androidComponents.onVariants` Variant API, with `versionName` as a single build-script source of truth.

## Testing

- `./gradlew :app:assembleDebug` → ✅ output `Mandacaru-0.10.3.apk`
- `./gradlew detekt` → ✅
- `./gradlew lintDebug` → ✅
- `./gradlew testDebugUnitTest` → ✅ (includes new `VersionComparatorTest`)

> Note: the in-app download/install path requires releases to attach a `.apk` asset (e.g. `Mandacaru-<version>.apk`); otherwise the button gracefully opens the release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)