### PR TITLE
fix: daemon fails to start on non-mainnet networks (no peers shown)

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -43,26 +43,23 @@ class FlorestaDaemonImpl(
             } else null
             val userAgent =
                 "/Floresta:${Constants.FLORESTA_VERSION}/mandacaru:${BuildConfig.VERSION_NAME}/"
-            val builtinSnapshotJson: String? = runCatching {
-                SnapshotCodec.normalizeToJson(Constants.BUILTIN_UTREEXO_SNAPSHOT_COMPACT)
-            }.onFailure {
-                Log.w(TAG, "builtin snapshot decode failed; falling back to Floresta default", it)
-            }.getOrNull()
+            val builtinSnapshotJson = builtinSnapshotFor(network)
             val startupSnapshotJson: String? = pendingSnapshot ?: builtinSnapshotJson
             val snapshotSource = when {
                 pendingSnapshot != null -> "pending"
                 builtinSnapshotJson != null -> "builtin"
                 else -> "floresta-default"
             }
+            val effectiveDataDir = dataDirFor(network)
             Log.i(
                 TAG,
                 "start: snapshotSource=$snapshotSource, " +
                     "snapshotLen=${startupSnapshotJson?.length ?: 0}, " +
-                    "network=$network, datadir=$datadir, " +
+                    "network=$network, datadir=$effectiveDataDir, " +
                     "filtersStartHeight=$filtersStartHeight, userAgent=$userAgent",
             )
             val config = Config(
-                dataDir = datadir,
+                dataDir = effectiveDataDir,
                 network = network,
                 assumeUtreexo = true,
                 userUtreexoSnapshotJson = startupSnapshotJson,
@@ -111,7 +108,11 @@ class FlorestaDaemonImpl(
                 IllegalStateException("Daemon is still running; call stop() first")
             )
         }
-        val base = File(datadir)
+        val network = preferencesDataSource.getString(
+            PreferenceKeys.CURRENT_NETWORK,
+            FlorestaNetwork.BITCOIN.name
+        ).toFlorestaNetwork()
+        val base = File(dataDirFor(network))
         listOf("chaindata", "cfilters").forEach { sub ->
             val dir = File(base, sub)
             val size = if (dir.exists()) dirSize(dir) else 0L
@@ -122,6 +123,35 @@ class FlorestaDaemonImpl(
 
     private fun dirSize(dir: File): Long =
         dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+
+    // The builtin snapshot is a mainnet dump; Floresta rejects it on other networks,
+    // so only apply it when running mainnet.
+    private fun builtinSnapshotFor(network: FlorestaNetwork): String? {
+        if (network != FlorestaNetwork.BITCOIN) return null
+        return runCatching {
+            SnapshotCodec.normalizeToJson(Constants.BUILTIN_UTREEXO_SNAPSHOT_COMPACT)
+        }.onFailure {
+            Log.w(TAG, "builtin snapshot decode failed; falling back to Floresta default", it)
+        }.getOrNull()
+    }
+
+    // Each network needs its own chain data. Mainnet keeps the flat base dir for
+    // backward compatibility with already-synced installs; other networks live in a
+    // dedicated subdir so they never collide with mainnet (or each other).
+    private fun dataDirFor(network: FlorestaNetwork): String {
+        if (network == FlorestaNetwork.BITCOIN) return datadir
+        val dir = File(datadir, network.dirName())
+        if (!dir.exists()) dir.mkdirs()
+        return dir.absolutePath
+    }
+
+    private fun FlorestaNetwork.dirName(): String = when (this) {
+        FlorestaNetwork.BITCOIN -> "bitcoin"
+        FlorestaNetwork.SIGNET -> "signet"
+        FlorestaNetwork.TESTNET -> "testnet"
+        FlorestaNetwork.TESTNET4 -> "testnet4"
+        FlorestaNetwork.REGTEST -> "regtest"
+    }
 
     companion object {
         private const val TAG = "FlorestaDaemonImpl"


### PR DESCRIPTION
## Problem

Switching the app from mainnet to **signet** (or testnet/regtest) silently killed the Floresta daemon at startup. Nothing listened on the network's RPC port, the Android poller got `ECONNREFUSED`, and the UI showed **no peers** and no blockchain info. The on-device `debug.log` still showed *mainnet* peers — stale lines from the previous process in the shared data dir — which made it look like the node was connected.

Captured from logcat:

```
FlorestaDaemonImpl: start: snapshotSource=builtin, ... network=SIGNET, ...
FlorestaDaemonImpl: start error:
com.florestad.InternalException: user_utreexo_snapshot_json is for a different network than Config.network
    at com.florestad.Florestad$Companion.fromConfig(florestad.kt:1330)
    at FlorestaDaemonImpl.start(FlorestaDaemonImpl.kt:72)
```

## Root causes (both in `FlorestaDaemonImpl.kt`)

1. **Builtin Utreexo snapshot is mainnet-only.** `Constants.BUILTIN_UTREEXO_SNAPSHOT_COMPACT` is a mainnet dump. Floresta records the network inside each snapshot and `Florestad.fromConfig()` rejects a cross-network dump (`NetworkMismatch`). `start()` applied it unconditionally, so `fromConfig` threw on every non-mainnet network — before the Rust tracing subscriber even initialized (hence nothing in `debug.log`).

2. **Data dir was flat and shared across networks.** `datadir = filesDir` with no per-network subdir, so a signet node would load mainnet's `chaindata`/`cfilters`/`db`.

## Fix

1. `builtinSnapshotFor(network)` returns the builtin snapshot **only on mainnet**; other networks pass `null` and fall back to Floresta's own per-network assumeutreexo default.
2. `dataDirFor(network)` keeps **mainnet on the flat base dir** (backward compat — no re-IBD for already-synced installs) and gives every other network its own `files/<network>/` subdir. `prepareForSnapshotImport()` resolves the same per-network dir.

## Verification (live, on-device)

After installing on a phone set to signet:

- `start: Floresta running`, `snapshotSource=floresta-default`, `datadir=.../files/signet`
- Connected to **10 signet peers** on port 38333 (peers at height 305853)
- App poller: `getpeerinfo` → 10 peers, `getblockchaininfo` → `"chain":"signet"` and syncing (height 0 → 10000), **no errors after the daemon came up**

`./gradlew detekt lintDebug` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)