### PR TITLE
fix: reject unsigned transactions before broadcast

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/TransactionDecoder.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/TransactionDecoder.kt
@@ -13,8 +13,12 @@ interface TransactionDecoder {
 /**
  * Turns a scanned payload into a broadcastable raw transaction. A PSBT (detected by its magic
  * bytes) is finalized and extracted, exposing its fee; a raw signed transaction is parsed directly
- * (its fee is unknown because the input amounts are not part of the serialization). Failures are
- * surfaced as a [TransactionDecodeException] wrapped in the returned [Result].
+ * (its fee is unknown because the input amounts are not part of the serialization).
+ *
+ * Transactions that aren't fully signed are rejected here, because the node can't catch them: a
+ * utreexo node keeps no UTXO set, so its `sendrawtransaction` only runs context-free checks and
+ * returns a txid even for an unsigned transaction. Failures are surfaced as a
+ * [TransactionDecodeException] wrapped in the returned [Result].
  */
 class BdkTransactionDecoder : TransactionDecoder {
 
@@ -31,15 +35,26 @@ class BdkTransactionDecoder : TransactionDecoder {
         }
         return psbt.use {
             val feeSats = runCatching { it.fee().toLong() }.getOrNull()
-            val tx = try {
-                it.extractTx()
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                throw TransactionDecodeException(
-                    "This PSBT isn't finalized yet. Finalize it on your signing device, then scan again.",
-                    e,
-                )
+            finalizeAndExtract(it).use { finalTx ->
+                ensureFullySigned(finalTx)
+                summarize(finalTx, feeSats, PayloadType.PSBT, transport)
             }
-            tx.use { finalTx -> summarize(finalTx, feeSats, PayloadType.PSBT, transport) }
+        }
+    }
+
+    private fun finalizeAndExtract(psbt: Psbt): Transaction {
+        val finalized = psbt.finalize()
+        if (!finalized.couldFinalize) {
+            throw TransactionDecodeException(
+                "This PSBT isn't fully signed yet. Sign it on your signing device, then scan again.",
+            )
+        }
+        return finalized.psbt.use { finalPsbt ->
+            try {
+                finalPsbt.extractTx()
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                throw TransactionDecodeException("Couldn't extract the transaction from this PSBT.", e)
+            }
         }
     }
 
@@ -49,7 +64,20 @@ class BdkTransactionDecoder : TransactionDecoder {
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             throw TransactionDecodeException("Couldn't read the scanned transaction.", e)
         }
-        return tx.use { summarize(it, feeSats = null, type = PayloadType.TRANSACTION, transport = transport) }
+        return tx.use {
+            ensureFullySigned(it)
+            summarize(it, feeSats = null, type = PayloadType.TRANSACTION, transport = transport)
+        }
+    }
+
+    private fun ensureFullySigned(tx: Transaction) {
+        val hasUnsignedInput = tx.input().any { it.scriptSig.toBytes().isEmpty() && it.witness.isEmpty() }
+        if (hasUnsignedInput) {
+            throw TransactionDecodeException(
+                "This transaction isn't fully signed, so it can't be broadcast. " +
+                    "Sign it on your signing device, then scan again.",
+            )
+        }
     }
 
     @OptIn(ExperimentalStdlibApi::class)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
@@ -35,9 +35,11 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -114,6 +116,7 @@ fun TransactionScanSheet(
                             contentAlignment = Alignment.Center,
                         ) {
                             ContinuousCameraPreview(
+                                enabled = uiState.scanError.isEmpty() && !uiState.isDecoding,
                                 onPayloadScanned = { onAction(TransactionAction.OnQrFrameScanned(it)) },
                                 modifier = Modifier
                                     .fillMaxSize()
@@ -259,11 +262,13 @@ private fun CameraDeniedFallback() {
 
 @Composable
 private fun ContinuousCameraPreview(
+    enabled: Boolean,
     onPayloadScanned: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val lastPayload = remember { AtomicReference<String?>(null) }
+    val isEnabled = rememberUpdatedState(enabled)
     val scanner = remember {
         BarcodeScanning.getClient(
             BarcodeScannerOptions.Builder()
@@ -272,6 +277,10 @@ private fun ContinuousCameraPreview(
         )
     }
     val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+    LaunchedEffect(enabled) {
+        if (enabled) lastPayload.set(null)
+    }
 
     AndroidView(
         modifier = modifier,
@@ -292,7 +301,7 @@ private fun ContinuousCameraPreview(
                     .also {
                         it.setAnalyzer(analysisExecutor) { proxy ->
                             processFrame(proxy, scanner) { payload ->
-                                if (lastPayload.getAndSet(payload) != payload) {
+                                if (isEnabled.value && lastPayload.getAndSet(payload) != payload) {
                                     onPayloadScanned(payload)
                                 }
                             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class TransactionViewModel(
     private val florestaRpc: FlorestaRpc,
@@ -26,6 +27,7 @@ class TransactionViewModel(
     val uiState = _uiState.asStateFlow()
 
     private var searchJob: Job? = null
+    private var scanErrorJob: Job? = null
 
     fun onAction(action: TransactionAction) {
         when (action) {
@@ -59,6 +61,7 @@ class TransactionViewModel(
     }
 
     private fun openScanner() {
+        scanErrorJob?.cancel()
         qrScanner.reset()
         _uiState.update {
             it.copy(
@@ -72,18 +75,19 @@ class TransactionViewModel(
     }
 
     private fun closeScanner() {
+        scanErrorJob?.cancel()
         qrScanner.reset()
         _uiState.update { it.copy(isScannerVisible = false, scanProgress = 0f, scanError = "") }
     }
 
     private fun handleScannedFrame(payload: String) {
-        if (_uiState.value.isDecoding || _uiState.value.decodedTx != null) return
+        val current = _uiState.value
+        if (current.isDecoding || current.decodedTx != null || current.scanError.isNotEmpty()) return
         when (val state = qrScanner.ingest(payload)) {
             is ScanState.Idle -> Unit
             is ScanState.InProgress ->
                 _uiState.update { it.copy(scanProgress = state.progress, scanError = "") }
-            is ScanState.Error ->
-                _uiState.update { it.copy(scanError = state.reason, scanProgress = 0f) }
+            is ScanState.Error -> showScanError(state.reason)
             is ScanState.Complete -> decodePayload(state)
         }
     }
@@ -104,14 +108,18 @@ class TransactionViewModel(
                 }
                 .onFailure { error ->
                     Log.e(TAG, "decode error: ${error.message}", error)
-                    _uiState.update {
-                        it.copy(
-                            scanError = error.message ?: "Couldn't decode the QR code",
-                            isDecoding = false,
-                            scanProgress = 0f,
-                        )
-                    }
+                    showScanError(error.message ?: "Couldn't decode the QR code")
                 }
+        }
+    }
+
+    private fun showScanError(reason: String) {
+        scanErrorJob?.cancel()
+        _uiState.update { it.copy(scanError = reason, scanProgress = 0f, isDecoding = false) }
+        scanErrorJob = viewModelScope.launch {
+            delay(SCAN_ERROR_COOLDOWN)
+            qrScanner.reset()
+            _uiState.update { it.copy(scanError = "", scanProgress = 0f) }
         }
     }
 
@@ -217,6 +225,7 @@ class TransactionViewModel(
     override fun onCleared() {
         super.onCleared()
         searchJob?.cancel()
+        scanErrorJob?.cancel()
     }
 
     companion object {
@@ -224,5 +233,6 @@ class TransactionViewModel(
         private const val PERCENTAGE_MULTIPLIER = 100
         private val SEARCH_REGEX = Regex("^[a-fA-F0-9]{64}$")
         private val BROADCAST_REGEX = Regex("^[a-fA-F0-9]+$")
+        private val SCAN_ERROR_COOLDOWN = 10.seconds
     }
 }


### PR DESCRIPTION
## Problem

Scanning (or pasting) an **unsigned** transaction showed a "broadcast successfully" result with a txid, even though the transaction was never signed and will never confirm.

The on-device Floresta node can't catch this: a utreexo node keeps no UTXO set, so `sendrawtransaction` only runs context-free checks and returns a txid for any structurally-valid tx — signed or not (reproduced on signet; reported upstream as getfloresta/Floresta#1084). So the app has to verify signed-ness itself before broadcasting.

`bdk`'s `Psbt.extractTx()` does **not** require finalization — it silently returns an unsigned transaction — so the previous "isn't finalized yet" guard rarely fired.

## Fix

In `BdkTransactionDecoder`:

- **PSBT:** call `Psbt.finalize()` first and require `couldFinalize`; otherwise reject with a clear "isn't fully signed yet" message before extracting.
- **Both PSBT and raw-tx paths:** `ensureFullySigned()` requires every input to carry a non-empty `scriptSig` **or** non-empty `witness`; otherwise reject. This catches raw unsigned txs and any partially-signed input.

The `TransactionDecodeException` propagates to the ViewModel's `decodePayload().onFailure`, so an unsigned scan now surfaces the error in the scanner instead of opening the confirmation sheet — it never reaches `sendrawtransaction`.

## Testing

- `./gradlew :app:compileDebugKotlin` — passes
- `./gradlew detekt` — passes

The decoder path needs bdk's native lib (device-only), so it isn't JVM-unit-tested; on-device end-to-end with a real unsigned PSBT QR is a manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
