### PR TITLE
fix: download update APK only, drop programmatic install

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateDownloader.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateDownloader.kt
@@ -5,16 +5,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.net.Uri
 import android.os.Environment
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 
 class AppUpdateDownloader(private val context: Context) {
 
-    fun canInstall(): Boolean = context.packageManager.canRequestPackageInstalls()
-
-    fun enqueue(url: String, fileName: String) {
+    fun enqueue(url: String, fileName: String, onComplete: () -> Unit) {
         val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val request = DownloadManager.Request(url.toUri())
             .setTitle(fileName)
@@ -22,17 +19,16 @@ class AppUpdateDownloader(private val context: Context) {
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
             .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
         val downloadId = downloadManager.enqueue(request)
-        registerCompletionReceiver(downloadManager, downloadId)
+        registerCompletionReceiver(downloadId, onComplete)
     }
 
-    private fun registerCompletionReceiver(downloadManager: DownloadManager, downloadId: Long) {
+    private fun registerCompletionReceiver(downloadId: Long, onComplete: () -> Unit) {
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 val completedId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
                 if (completedId != downloadId) return
                 context.unregisterReceiver(this)
-                downloadManager.getUriForDownloadedFile(downloadId)
-                    ?.let { uri -> launchInstaller(context, uri) }
+                onComplete()
             }
         }
         ContextCompat.registerReceiver(
@@ -41,15 +37,6 @@ class AppUpdateDownloader(private val context: Context) {
             IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
             ContextCompat.RECEIVER_EXPORTED,
         )
-    }
-
-    private fun launchInstaller(context: Context, uri: Uri) {
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, APK_MIME_TYPE)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        context.startActivity(intent)
     }
 
     companion object {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -1,10 +1,6 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 
 import android.content.Intent
-import android.provider.Settings
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.net.toUri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -54,6 +50,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -121,11 +118,6 @@ fun ScreenSettings(
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val shareLogsTitle = stringResource(R.string.share_logs)
-    val installPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        viewModel.onAction(SettingsAction.OnClickDownloadUpdate)
-    }
     ScreenSettings(
         uiState = uiState,
         onAction = viewModel::onAction,
@@ -145,14 +137,6 @@ fun ScreenSettings(
                     }
                     context.startActivity(
                         Intent.createChooser(shareIntent, shareLogsTitle)
-                    )
-                }
-                is SettingsEvents.RequestInstallPermission -> {
-                    installPermissionLauncher.launch(
-                        Intent(
-                            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-                            "package:${context.packageName}".toUri()
-                        )
                     )
                 }
                 is SettingsEvents.OpenReleasePage -> uriHandler.openUri(event.url)
@@ -777,6 +761,7 @@ private fun ScreenSettings(
 
                             UpdateRow(
                                 updateStatus = uiState.updateStatus,
+                                isDownloading = uiState.isDownloading,
                                 onAction = onAction,
                             )
                         }
@@ -893,6 +878,7 @@ private fun BirthdayRestartConfirmDialog(
 @Composable
 private fun UpdateRow(
     updateStatus: UpdateStatus,
+    isDownloading: Boolean,
     onAction: (SettingsAction) -> Unit,
 ) {
     val uriHandler = LocalUriHandler.current
@@ -922,16 +908,27 @@ private fun UpdateRow(
                 Spacer(modifier = Modifier.height(12.dp))
                 Button(
                     onClick = { onAction(SettingsAction.OnClickDownloadUpdate) },
+                    enabled = !isDownloading,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(12.dp),
                 ) {
-                    Icon(
-                        Icons.Outlined.Download,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.size(8.dp))
-                    Text(stringResource(R.string.download_update))
+                    if (isDownloading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(stringResource(R.string.downloading_update))
+                    } else {
+                        Icon(
+                            Icons.Outlined.Download,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(stringResource(R.string.download_update))
+                    }
                 }
             }
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
@@ -4,6 +4,5 @@ sealed interface SettingsEvents {
     data object OnNetworkChanged : SettingsEvents
     data object OnBirthdayChanged : SettingsEvents
     data class OnExportLogs(val uri: android.net.Uri) : SettingsEvents
-    data object RequestInstallPermission : SettingsEvents
     data class OpenReleasePage(val url: String) : SettingsEvents
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -28,4 +28,5 @@ data class SettingsUiState(
     val isBirthdayPickerOpen: Boolean = false,
     val pendingBirthdayYear: Int? = null,
     val updateStatus: UpdateStatus = UpdateStatus(),
+    val isDownloading: Boolean = false,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -162,17 +162,17 @@ class SettingsViewModel(
     }
 
     private fun downloadUpdate() {
+        if (_uiState.value.isDownloading) return
         val status = _uiState.value.updateStatus
         val url = status.apkDownloadUrl
         if (url == null) {
             viewModelScope.sendEvent(SettingsEvents.OpenReleasePage(status.releasePageUrl))
             return
         }
-        if (!appUpdateDownloader.canInstall()) {
-            viewModelScope.sendEvent(SettingsEvents.RequestInstallPermission)
-            return
+        _uiState.update { it.copy(isDownloading = true) }
+        appUpdateDownloader.enqueue(url, "Mandacaru-${status.latestVersion}.apk") {
+            _uiState.update { it.copy(isDownloading = false) }
         }
-        appUpdateDownloader.enqueue(url, "Mandacaru-${status.latestVersion}.apk")
     }
 
     private fun applyBirthdayYearAndRestart() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="update_available">Update available</string>
     <string name="latest_version">Latest: %1$s</string>
     <string name="download_update">Download update</string>
+    <string name="downloading_update">Downloading…</string>
     <string name="up_to_date">You\'re on the latest version</string>
     <string name="donate">Donate</string>
     <string name="lightning_address">Lightning Address</string>


### PR DESCRIPTION
Closes #94.

## Problem

Installing an update via the in-app flow triggered Google Play Protect's "Harmful app blocked, app not installed" warning. The cause was the programmatic `ACTION_VIEW` install launched right after the download completed.

## Change

The update feature now **only downloads** the APK. The user installs it from the DownloadManager completion notification themselves, which avoids the silent Play Protect block.

- Removed `launchInstaller()` / `canInstall()` from `AppUpdateDownloader`; `enqueue()` now takes an `onComplete` callback instead of launching the installer.
- Removed the `REQUEST_INSTALL_PACKAGES` manifest permission, the `RequestInstallPermission` event, and the `ACTION_MANAGE_UNKNOWN_APP_SOURCES` launcher.
- **Loading state on the Download button:** it disables and shows a spinner ("Downloading…") while a download is in progress, and `downloadUpdate()` early-returns if one is already running — preventing duplicate downloads.

## Verification

`./gradlew :app:compileDebugKotlin detekt lintDebug` → BUILD SUCCESSFUL. Remaining warnings are pre-existing deprecations unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)