### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ val localProperties = Properties().apply {
     if (file.exists()) load(file.inputStream())
 }
 
-val appVersionName = "0.11.2"
+val appVersionName = "0.11.3"
 
 plugins {
     alias(libs.plugins.android.application)
@@ -22,7 +22,7 @@ android {
         applicationId = "com.github.jvsena42.mandacaru"
         minSdk = 29
         targetSdk = 36
-        versionCode = 24
+        versionCode = 25
         versionName = appVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Release v0.11.3.

Ships (since v0.11.2):
- **Blue Wallet / Electrum transactions now display** — Floresta's Electrum `blockchain.transaction.get` now supports verbose mode.
- Node synced with upstream Floresta master (refactors + DoS/security fixes).
- Updated bundled Utreexo accumulator snapshot (faster initial sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)