### PR TITLE
feat: WiFi-only by default with opt-in mobile data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
@@ -12,6 +12,7 @@ import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.data.PreferencesDataSourceImpl
 import com.github.jvsena42.mandacaru.data.floresta.FlorestaDaemonImpl
 import com.github.jvsena42.mandacaru.data.floresta.FlorestaRpcImpl
+import com.github.jvsena42.mandacaru.data.network.NetworkPolicyManager
 import com.github.jvsena42.mandacaru.data.update.AppUpdateRepositoryImpl
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
@@ -28,6 +29,7 @@ import com.github.jvsena42.mandacaru.presentation.ui.screens.settings.SettingsVi
 import com.google.gson.Gson
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
+import org.koin.android.ext.android.inject
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -40,6 +42,8 @@ val Context.florestaDataStore: DataStore<Preferences> by preferencesDataStore(
 )
 
 class MandacaruApplication : Application() {
+    private val networkPolicyManager: NetworkPolicyManager by inject()
+
     override fun onCreate() {
         super.onCreate()
         startKoin {
@@ -50,6 +54,9 @@ class MandacaruApplication : Application() {
                 dataModule
             )
         }
+        // Bind the process network before the service starts the daemon, so the
+        // very first peer socket already respects the WiFi-only policy.
+        networkPolicyManager.apply()
     }
 }
 
@@ -60,6 +67,7 @@ val presentationModule = module {
             snapshotService = get(),
             florestaDaemon = get(),
             preferencesDataSource = get(),
+            networkPolicyManager = get(),
         )
     }
     viewModel {
@@ -95,6 +103,12 @@ val dataModule = module {
     single<PreferencesDataSource> {
         PreferencesDataSourceImpl(
             dataStore = androidContext().florestaDataStore
+        )
+    }
+    single {
+        NetworkPolicyManager(
+            context = androidContext(),
+            preferencesDataSource = get()
         )
     }
     single { UtreexoBridgeAutoConnect(florestaRpc = get(), preferencesDataSource = get()) }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
@@ -12,5 +12,6 @@ enum class PreferenceKeys(val dataStoreKey: Preferences.Key<String>) {
     UPDATE_LAST_CHECK(stringPreferencesKey("UPDATE_LAST_CHECK")),
     UPDATE_LATEST_VERSION(stringPreferencesKey("UPDATE_LATEST_VERSION")),
     UPDATE_LATEST_APK_URL(stringPreferencesKey("UPDATE_LATEST_APK_URL")),
-    UPDATE_SEEN_VERSION(stringPreferencesKey("UPDATE_SEEN_VERSION"))
+    UPDATE_SEEN_VERSION(stringPreferencesKey("UPDATE_SEEN_VERSION")),
+    USE_ALSO_MOBILE_DATA(stringPreferencesKey("USE_ALSO_MOBILE_DATA"))
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/network/NetworkPolicyManager.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/network/NetworkPolicyManager.kt
@@ -1,0 +1,97 @@
+package com.github.jvsena42.mandacaru.data.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Enforces the WiFi-only / "also use mobile data" policy process-wide.
+ *
+ * The Floresta daemon runs inside this app's own process, so its native TCP
+ * sockets (and DNS lookups) follow [ConnectivityManager.bindProcessToNetwork].
+ * Binding the process to a WiFi [Network] therefore keeps every peer connection
+ * off cellular without any change to the Rust side. Loopback traffic
+ * (the localhost JSON-RPC between UI and daemon) is routed over `lo` and stays
+ * reachable regardless of the bound network.
+ */
+class NetworkPolicyManager(
+    context: Context,
+    private val preferencesDataSource: PreferencesDataSource,
+) {
+    private val connectivityManager =
+        context.getSystemService(ConnectivityManager::class.java)
+
+    private val _isWaitingForWifi = MutableStateFlow(false)
+    val isWaitingForWifi: StateFlow<Boolean> = _isWaitingForWifi.asStateFlow()
+
+    private var wifiCallback: ConnectivityManager.NetworkCallback? = null
+
+    /**
+     * Reads the current preference and (re)configures the binding. Safe to call
+     * again after the preference changes; an app restart still happens on toggle
+     * so existing daemon sockets are torn down, but re-applying keeps the
+     * callback in a single, correct state.
+     */
+    fun apply() {
+        val allowMobileData = runBlocking {
+            preferencesDataSource.getBoolean(PreferenceKeys.USE_ALSO_MOBILE_DATA, false)
+        }
+        unregisterWifiCallback()
+        if (allowMobileData) {
+            connectivityManager?.bindProcessToNetwork(null)
+            _isWaitingForWifi.value = false
+            Log.i(TAG, "apply: mobile data allowed — using system default network")
+        } else {
+            enforceWifiOnly()
+        }
+    }
+
+    private fun enforceWifiOnly() {
+        val cm = connectivityManager ?: return
+        // Assume no WiFi until onAvailable confirms one, closing the startup
+        // window before the callback fires.
+        _isWaitingForWifi.value = true
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                Log.i(TAG, "WiFi available — binding process to it")
+                cm.bindProcessToNetwork(network)
+                _isWaitingForWifi.value = false
+            }
+
+            override fun onLost(network: Network) {
+                // Do not rebind to null: that would let new sockets fall back to
+                // cellular. Stay bound to the (now gone) WiFi network so sockets
+                // simply fail until WiFi returns.
+                Log.i(TAG, "WiFi lost — sync paused until WiFi returns")
+                _isWaitingForWifi.value = true
+            }
+        }
+        wifiCallback = callback
+        cm.requestNetwork(request, callback)
+        Log.i(TAG, "apply: WiFi-only enforced")
+    }
+
+    private fun unregisterWifiCallback() {
+        wifiCallback?.let { cb ->
+            runCatching { connectivityManager?.unregisterNetworkCallback(cb) }
+        }
+        wifiCallback = null
+    }
+
+    private companion object {
+        const val TAG = "NetworkPolicyManager"
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
@@ -14,6 +14,7 @@ import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.data.network.NetworkPolicyManager
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
@@ -27,6 +28,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -41,8 +43,11 @@ class FlorestaService : Service() {
     private val florestaRpc: FlorestaRpc by inject()
     private val utreexoBridgeAutoConnect: UtreexoBridgeAutoConnect by inject()
     private val preferencesDataSource: PreferencesDataSource by inject()
+    private val networkPolicyManager: NetworkPolicyManager by inject()
     private val isStopping = AtomicBoolean(false)
     private var notificationPollingJob: Job? = null
+    private var wifiStateJob: Job? = null
+    @Volatile private var waitingForWifi = false
     private var startupSeedDone = false
     private var fullySyncedSinceMs: Long? = null
     private val rescanInFlight = AtomicBoolean(false)
@@ -147,6 +152,7 @@ class FlorestaService : Service() {
                         florestaDaemon.start()
                     }
                     startNotificationPolling()
+                    observeWifiState()
                 } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                     Log.e(TAG, "onStartCommand error: ", e)
                 }
@@ -154,6 +160,23 @@ class FlorestaService : Service() {
         }
 
         return START_STICKY
+    }
+
+    private fun observeWifiState() {
+        wifiStateJob?.cancel()
+        wifiStateJob = ioScope.launch {
+            networkPolicyManager.isWaitingForWifi.collect { waiting ->
+                waitingForWifi = waiting
+                if (waiting) {
+                    val notificationManager =
+                        getSystemService(NotificationManager::class.java)
+                    notificationManager?.notify(
+                        FLORESTA_NOTIFICATION_ID,
+                        createWaitingForWifiNotification()
+                    )
+                }
+            }
+        }
     }
 
     private fun startNotificationPolling() {
@@ -266,6 +289,14 @@ class FlorestaService : Service() {
     ) {
         val notificationManager = getSystemService(NotificationManager::class.java) ?: return
 
+        if (waitingForWifi) {
+            notificationManager.notify(
+                FLORESTA_NOTIFICATION_ID,
+                createWaitingForWifiNotification()
+            )
+            return
+        }
+
         val openAppIntent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
@@ -358,6 +389,7 @@ class FlorestaService : Service() {
         }
         Log.d(TAG, "stopServiceAndExitApp called")
         notificationPollingJob?.cancel()
+        wifiStateJob?.cancel()
 
         // Update notification to show shutdown in progress
         val notificationManager = getSystemService(NotificationManager::class.java)
@@ -392,6 +424,37 @@ class FlorestaService : Service() {
         }
     }
 
+    private fun createWaitingForWifiNotification(): Notification {
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val openAppPendingIntent = PendingIntent.getActivity(
+            this, 0, openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val stopIntent = Intent(this, FlorestaService::class.java).apply {
+            action = ACTION_STOP_SERVICE
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            this, 1, stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Mandacaru")
+            .setContentText(getString(R.string.waiting_for_wifi))
+            .setSubText(getString(R.string.waiting_for_wifi_subtitle))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setAutoCancel(false)
+            .setOngoing(true)
+            .setColor(COLOR_PRIMARY.toColorInt())
+            .setColorized(true)
+            .setContentIntent(openAppPendingIntent)
+            .addAction(R.drawable.ic_x, "Stop", stopPendingIntent)
+            .build()
+    }
+
     private fun createStoppingNotification(): Notification {
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Mandacaru")
@@ -412,6 +475,7 @@ class FlorestaService : Service() {
         super.onDestroy()
         Log.d(TAG, "onDestroy called")
         notificationPollingJob?.cancel()
+        wifiStateJob?.cancel()
         if (isStopping.compareAndSet(false, true)) {
             // Only stop daemon here if stopServiceAndExitApp wasn't called
             runBlocking(Dispatchers.IO) {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -43,4 +43,5 @@ data class NodeUiState(
     val exportPayload: String? = null,
     val snapshotMessage: String? = null,
     val isApplyingSnapshot: Boolean = false,
+    val isWaitingForWifi: Boolean = false,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -8,6 +8,7 @@ import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.data.floresta.toFlorestaNetwork
+import com.github.jvsena42.mandacaru.data.network.NetworkPolicyManager
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
@@ -23,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
@@ -34,6 +36,7 @@ class NodeViewModel(
     private val snapshotService: UtreexoSnapshotService,
     private val florestaDaemon: FlorestaDaemon,
     private val preferencesDataSource: PreferencesDataSource,
+    private val networkPolicyManager: NetworkPolicyManager,
 ) : ViewModel(), EventFlow<NodeEvents> by EventFlowImpl() {
 
     private val _uiState = MutableStateFlow(NodeUiState())
@@ -41,6 +44,11 @@ class NodeViewModel(
 
     init {
         getInLoop()
+        viewModelScope.launch {
+            networkPolicyManager.isWaitingForWifi.collect { waiting ->
+                _uiState.update { it.copy(isWaitingForWifi = waiting) }
+            }
+        }
     }
 
     private fun getInLoop() {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.LinkOff
 import androidx.compose.material.icons.outlined.NetworkPing
 import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material.icons.outlined.WifiOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -149,31 +150,89 @@ fun ScreenNode(
         containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets(0),
     ) { padding ->
-        ScreenNode(
-            uiState = uiState,
-            modifier = Modifier.padding(padding),
-            bottomContentPadding = bottomContentPadding,
-            onTogglePeers = viewModel::togglePeersExpanded,
-            onToggleDiagnostics = viewModel::toggleDiagnosticsExpanded,
-            onDisconnectPeer = viewModel::disconnectPeer,
-            onPingPeers = viewModel::pingPeers,
-            onClickScan = viewModel::onClickScan,
-            onClickPaste = viewModel::onClickPaste,
-            onDismissScanSheet = viewModel::onDismissScanSheet,
-            onDismissPasteSheet = viewModel::onDismissPasteSheet,
-            onAccumulatorReceived = viewModel::onAccumulatorReceived,
-            onDismissImportConfirm = viewModel::onDismissImportConfirm,
-            onConfirmImport = viewModel::onConfirmImport,
-            onToggleImportCard = viewModel::toggleImportCardExpanded,
-            onToggleExportCard = viewModel::toggleExportCardExpanded,
-            onClickShowExportQr = viewModel::onClickShowExportQr,
-            onClickCopyExport = {
-                viewModel.onClickCopyExport()
-                uiState.exportPayload?.let { clipboard.setText(AnnotatedString(it)) }
-            },
-            onClickShareExport = viewModel::onClickShareExport,
-            onDismissExportQrSheet = viewModel::onDismissExportQrSheet,
+        // Match the inner content's adaptive width/padding so the banner lines
+        // up with the centered, width-capped layout on tablets instead of
+        // spanning full-bleed above it.
+        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
+            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
         )
+        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
+            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
+        )
+        val bannerHorizontalPadding = when {
+            isExpandedWidth -> 32.dp
+            isMediumOrWider -> 24.dp
+            else -> 16.dp
+        }
+        // The expanded (tablet) dashboard fills the full pager width, while the
+        // compact/medium layouts cap and center their content; mirror that so the
+        // banner always spans the same width as the content beneath it.
+        val bannerWidth = if (isExpandedWidth) {
+            Modifier.fillMaxWidth()
+        } else {
+            Modifier
+                .widthIn(max = if (isMediumOrWider) 1200.dp else 600.dp)
+                .fillMaxWidth()
+        }
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (uiState.isWaitingForWifi) {
+                Card(
+                    modifier = bannerWidth
+                        .padding(horizontal = bannerHorizontalPadding, vertical = 8.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.WifiOff,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(R.string.waiting_for_wifi),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    }
+                }
+            }
+            ScreenNode(
+                uiState = uiState,
+                modifier = Modifier.weight(1f),
+                bottomContentPadding = bottomContentPadding,
+                onTogglePeers = viewModel::togglePeersExpanded,
+                onToggleDiagnostics = viewModel::toggleDiagnosticsExpanded,
+                onDisconnectPeer = viewModel::disconnectPeer,
+                onPingPeers = viewModel::pingPeers,
+                onClickScan = viewModel::onClickScan,
+                onClickPaste = viewModel::onClickPaste,
+                onDismissScanSheet = viewModel::onDismissScanSheet,
+                onDismissPasteSheet = viewModel::onDismissPasteSheet,
+                onAccumulatorReceived = viewModel::onAccumulatorReceived,
+                onDismissImportConfirm = viewModel::onDismissImportConfirm,
+                onConfirmImport = viewModel::onConfirmImport,
+                onToggleImportCard = viewModel::toggleImportCardExpanded,
+                onToggleExportCard = viewModel::toggleExportCardExpanded,
+                onClickShowExportQr = viewModel::onClickShowExportQr,
+                onClickCopyExport = {
+                    viewModel.onClickCopyExport()
+                    uiState.exportPayload?.let { clipboard.setText(AnnotatedString(it)) }
+                },
+                onClickShareExport = viewModel::onClickShareExport,
+                onDismissExportQrSheet = viewModel::onDismissExportQrSheet,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.NetworkCheck
+import androidx.compose.material.icons.outlined.DataUsage
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Wallet
@@ -66,6 +67,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -129,6 +131,7 @@ fun ScreenSettings(
         viewModel.eventFlow.collect { event ->
             when (event) {
                 is SettingsEvents.OnNetworkChanged -> currentRestartApplication()
+                is SettingsEvents.OnNetworkPolicyChanged -> currentRestartApplication()
                 is SettingsEvents.OnBirthdayChanged -> currentRestartApplication()
                 is SettingsEvents.OnExportLogs -> {
                     val shareIntent = Intent(Intent.ACTION_SEND).apply {
@@ -501,6 +504,59 @@ private fun ScreenSettings(
                                         )
                                     }
                                 }
+                            }
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            Card(
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                )
+                            ) {
+                                Text(
+                                    stringResource(R.string.the_application_will_be_restarted_to_update_the_network),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.padding(12.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Data usage Section
+                item {
+                    SectionCard(
+                        title = stringResource(R.string.data_usage),
+                        icon = Icons.Outlined.DataUsage,
+                        isExpanded = uiState.isDataUsageExpanded,
+                        onToggle = { onAction(SettingsAction.ToggleDataUsageExpanded) },
+                        modifier = Modifier.animateItem(),
+                    ) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = stringResource(R.string.also_use_mobile_data),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.also_use_mobile_data_subtitle),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Switch(
+                                    checked = uiState.useAlsoMobileData,
+                                    onCheckedChange = { onAction(SettingsAction.OnToggleMobileData(it)) },
+                                    modifier = Modifier
+                                        .padding(start = 12.dp)
+                                        .testTag("toggle_mobile_data"),
+                                )
                             }
 
                             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -24,4 +24,6 @@ sealed interface SettingsAction {
     object OnDismissBirthdayPicker: SettingsAction
     object OnConfirmBirthdayRestart: SettingsAction
     object OnCancelBirthdayRestart: SettingsAction
+    object ToggleDataUsageExpanded: SettingsAction
+    data class OnToggleMobileData(val enabled: Boolean): SettingsAction
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 
 sealed interface SettingsEvents {
     data object OnNetworkChanged : SettingsEvents
+    data object OnNetworkPolicyChanged : SettingsEvents
     data object OnBirthdayChanged : SettingsEvents
     data class OnExportLogs(val uri: android.net.Uri) : SettingsEvents
     data class OpenReleasePage(val url: String) : SettingsEvents

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -31,4 +31,6 @@ data class SettingsUiState(
     val isRescanning: Boolean = false,
     val rescanBlocksProcessed: Int? = null,
     val rescanBlocksTotal: Int? = null,
+    val useAlsoMobileData: Boolean = false,
+    val isDataUsageExpanded: Boolean = false,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -55,6 +55,8 @@ class SettingsViewModel(
                 .getString(PreferenceKeys.WALLET_BIRTHDAY_YEAR, "")
                 .toIntOrNull()
                 ?: WalletBirthday.defaultYear()
+            val useAlsoMobileData = preferencesDataSource
+                .getBoolean(PreferenceKeys.USE_ALSO_MOBILE_DATA, false)
             _uiState.update {
                 it.copy(
                     selectedNetwork = preferencesDataSource.getString(
@@ -62,6 +64,7 @@ class SettingsViewModel(
                         FlorestaNetwork.BITCOIN.name
                     ),
                     walletBirthdayYear = birthdayYear,
+                    useAlsoMobileData = useAlsoMobileData,
                 )
             }
             updateElectrumAddress()
@@ -110,7 +113,7 @@ class SettingsViewModel(
         }
     }
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     fun onAction(action: SettingsAction) {
         when (action) {
             is SettingsAction.OnDescriptorChanged -> {
@@ -183,6 +186,24 @@ class SettingsViewModel(
             }
 
             SettingsAction.OnConfirmBirthdayRestart -> applyBirthdayYearAndRestart()
+            SettingsAction.ToggleDataUsageExpanded -> toggleDataUsageExpanded()
+            is SettingsAction.OnToggleMobileData -> handleMobileDataToggled(action)
+        }
+    }
+
+    private fun toggleDataUsageExpanded() = _uiState.update {
+        it.copy(isDataUsageExpanded = !it.isDataUsageExpanded)
+    }
+
+    private fun handleMobileDataToggled(action: SettingsAction.OnToggleMobileData) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesDataSource.setBoolean(
+                PreferenceKeys.USE_ALSO_MOBILE_DATA,
+                action.enabled
+            )
+            _uiState.update { it.copy(useAlsoMobileData = action.enabled, isLoading = true) }
+            delay(2.seconds)
+            viewModelScope.sendEvent(SettingsEvents.OnNetworkPolicyChanged)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,11 @@
     <string name="node_address_error_invalid_port">Invalid port. Must be between 1 and 65535.</string>
     <string name="select_a_network">Select a network</string>
     <string name="the_application_will_be_restarted_to_update_the_network">The application will be restarted to update the network</string>
+    <string name="data_usage">Data usage</string>
+    <string name="also_use_mobile_data">Also use mobile data</string>
+    <string name="also_use_mobile_data_subtitle">When off, the node syncs only over Wi-Fi to avoid using mobile data</string>
+    <string name="waiting_for_wifi">Waiting for Wi-Fi</string>
+    <string name="waiting_for_wifi_subtitle">Sync paused — connect to Wi-Fi or allow mobile data in Settings</string>
     <string name="validated_blocks">Validated Blocks</string>
     <string name="descriptors">Descriptors</string>
     <string name="no_descriptors_loaded">No descriptors loaded yet</string>

--- a/journeys/README.md
+++ b/journeys/README.md
@@ -104,6 +104,11 @@ when adding or renaming a tag.
 | `input_descriptor`          | wallet descriptor field                |
 | `button_update_descriptor`  | "Update descriptor"                    |
 | `input_network`             | network selector field                 |
+| `toggle_mobile_data`        | "Also use mobile data" switch          |
+
+The Data usage section's `toggle_mobile_data` switch is off by default (Wi-Fi only);
+turning it on persists the preference and restarts the app. Expand the "Data usage"
+section by text before asserting on it.
 
 Tapping `input_network` opens the network dropdown. Its options are **targeted by text**
 (`BITCOIN`, `SIGNET`, `TESTNET`, `REGTEST`, `TESTNET4`) — see the popup caveat below.


### PR DESCRIPTION
Closes #3

## What & why
The on-device Floresta node opens its own TCP sockets to Bitcoin peers and downloads the chain + compact filters — potentially GBs. Until now there was **no** network-type policy, so a user on mobile data could rack up usage unknowingly. This makes the app **Wi-Fi-only by default**, with an explicit opt-in to also use mobile data — and ensures the Rust daemon can't bypass it.

## How it works
The daemon runs **inside the app's own process**, so `ConnectivityManager.bindProcessToNetwork()` routes **all** sockets — including the daemon's native Rust sockets — and DNS over the bound network. No FFI/Rust changes needed.

- **`NetworkPolicyManager`** (new): in Wi-Fi-only mode it `requestNetwork()`s a WiFi+Internet network and binds the process to it; when "also use mobile data" is on it binds to the system default (WiFi preferred, cellular fallback). On WiFi loss it **stays bound** (never falls back to cellular) and flips a `Waiting for Wi-Fi` flag.
- Applied in `MandacaruApplication.onCreate()` **before** the service starts the daemon, so the first peer socket already respects the policy.
- **Settings → Data usage:** "Also use mobile data" toggle (default off). Persists and restarts the app (same pattern as the network change) so the daemon re-binds cleanly.
- **Waiting-for-Wi-Fi UX:** distinct foreground-service notification + a Node-screen banner (uses the app's `errorContainer` warning style; width adapts to tablet/phone layouts).
- Adds `CHANGE_NETWORK_STATE` permission; documents the `toggle_mobile_data` testTag in `journeys/README.md`.

## Verification (on an ARM64 device)
- ✅ Startup binds to WiFi; localhost JSON-RPC keeps working while bound (Node screen syncs to 99.96%, 9 peers).
- ✅ Toggle ON → restart → `mobile data allowed`; persists as checked; toggle OFF → restart → `WiFi-only enforced`.
- ✅ WiFi off (WiFi-only) → no cellular fallback, peers drop to 0, "Waiting for Wi-Fi" shows in notification + Node banner; WiFi back → rebinds, banner clears, sync resumes.
- ✅ Tablet layout: banner spans full content width and matches the dashboard; Settings "Data usage" section flows into the multi-column grid like other sections.
- ✅ `assembleDebug`, `detekt`, `lintDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)