### PR TITLE
feat: copy loaded wallet descriptors to clipboard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.org.json)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockito.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -307,24 +307,46 @@ private fun ScreenSettings(
                         onToggle = { onAction(SettingsAction.ToggleDescriptorsExpanded) },
                         modifier = Modifier.animateItem(),
                     ) {
+                        val clipboardManager = LocalClipboardManager.current
                         Column(modifier = Modifier.fillMaxWidth()) {
                             if (uiState.descriptors.isNotEmpty()) {
                                 uiState.descriptors.forEach { descriptor ->
                                     Surface(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(vertical = 4.dp),
+                                            .padding(vertical = 4.dp)
+                                            .clickable {
+                                                clipboardManager.setText(AnnotatedString(descriptor))
+                                                onAction(SettingsAction.OnDescriptorCopied(descriptor))
+                                            }
+                                            .testTag("button_copy_descriptor"),
                                         shape = RoundedCornerShape(8.dp),
                                         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
                                     ) {
-                                        Text(
-                                            text = descriptor,
-                                            fontFamily = FontFamily.Monospace,
-                                            style = MaterialTheme.typography.bodySmall,
-                                            maxLines = 2,
-                                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                                            modifier = Modifier.padding(12.dp)
-                                        )
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(12.dp),
+                                            horizontalArrangement = Arrangement.SpaceBetween,
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Text(
+                                                text = descriptor,
+                                                fontFamily = FontFamily.Monospace,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                maxLines = 2,
+                                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                                modifier = Modifier.weight(1f)
+                                            )
+                                            Icon(
+                                                Icons.Outlined.ContentCopy,
+                                                contentDescription = "Copy",
+                                                modifier = Modifier
+                                                    .padding(start = 12.dp)
+                                                    .size(20.dp),
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -12,6 +12,7 @@ sealed interface SettingsAction {
     data class OnDescriptorQrFrameScanned(val raw: String): SettingsAction
     object OnConfirmScannedDescriptor: SettingsAction
     object OnDismissScannedDescriptor: SettingsAction
+    data class OnDescriptorCopied(val descriptor: String): SettingsAction
     object OnClickConnectNode: SettingsAction
     object OnClickRescan: SettingsAction
     object ClearSnackBarMessage: SettingsAction

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -136,6 +136,10 @@ class SettingsViewModel(
                 it.copy(pendingScannedDescriptor = null)
             }
 
+            is SettingsAction.OnDescriptorCopied -> _uiState.update {
+                it.copy(snackBarMessage = "Descriptor copied to clipboard")
+            }
+
             SettingsAction.OnClickRescan -> rescan()
             SettingsAction.ClearSnackBarMessage -> _uiState.update { it.copy(snackBarMessage = "") }
             SettingsAction.OnClickConnectNode -> connectNode()

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
@@ -1,0 +1,114 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
+
+import android.content.Context
+import com.github.jvsena42.mandacaru.data.AppUpdateRepository
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
+import com.github.jvsena42.mandacaru.domain.scan.DescriptorQrScanner
+import com.github.jvsena42.mandacaru.domain.scan.DescriptorScanState
+import com.github.jvsena42.mandacaru.fakes.FakeFlorestaRpc
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+/**
+ * Covers the copy-descriptor-to-clipboard flow added in #113: tapping a loaded descriptor
+ * surfaces the "copied" confirmation, and clearing it resets the message. The clipboard
+ * write itself lives in the Composable; the ViewModel only owns the confirmation message.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var rpc: FakeFlorestaRpc
+    private lateinit var preferences: FakePreferences
+    private lateinit var appUpdateRepository: FakeAppUpdateRepository
+    private lateinit var descriptorScanner: FakeDescriptorQrScanner
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        rpc = FakeFlorestaRpc()
+        preferences = FakePreferences()
+        appUpdateRepository = FakeAppUpdateRepository()
+        descriptorScanner = FakeDescriptorQrScanner()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun buildViewModel(): SettingsViewModel {
+        val vm = SettingsViewModel(
+            florestaRpc = rpc,
+            preferencesDataSource = preferences,
+            appUpdateRepository = appUpdateRepository,
+            descriptorScanner = descriptorScanner,
+            context = mock(Context::class.java),
+        )
+        // runCurrent (not advanceUntilIdle): observeRescanState is an infinite delay loop
+        // that would never let advanceUntilIdle return; runCurrent parks it at the first delay.
+        dispatcher.scheduler.runCurrent()
+        return vm
+    }
+
+    @Test
+    fun `copying a descriptor surfaces the copied confirmation`() {
+        val vm = buildViewModel()
+
+        vm.onAction(SettingsAction.OnDescriptorCopied(DESCRIPTOR))
+        dispatcher.scheduler.runCurrent()
+
+        assertEquals("Descriptor copied to clipboard", vm.uiState.value.snackBarMessage)
+    }
+
+    @Test
+    fun `clearing the snackbar resets the message`() {
+        val vm = buildViewModel()
+        vm.onAction(SettingsAction.OnDescriptorCopied(DESCRIPTOR))
+        dispatcher.scheduler.runCurrent()
+
+        vm.onAction(SettingsAction.ClearSnackBarMessage)
+        dispatcher.scheduler.runCurrent()
+
+        assertEquals("", vm.uiState.value.snackBarMessage)
+    }
+
+    private class FakePreferences : PreferencesDataSource {
+        private val strings = mutableMapOf<PreferenceKeys, String>()
+        private val booleans = mutableMapOf<PreferenceKeys, Boolean>()
+        override suspend fun setString(key: PreferenceKeys, value: String) { strings[key] = value }
+        override suspend fun getString(key: PreferenceKeys, defaultValue: String): String =
+            strings[key] ?: defaultValue
+        override suspend fun setBoolean(key: PreferenceKeys, value: Boolean) { booleans[key] = value }
+        override suspend fun getBoolean(key: PreferenceKeys, defaultValue: Boolean): Boolean =
+            booleans[key] ?: defaultValue
+    }
+
+    private class FakeAppUpdateRepository : AppUpdateRepository {
+        override val updateStatus: StateFlow<UpdateStatus> = MutableStateFlow(UpdateStatus())
+        override suspend fun refresh(force: Boolean) = Unit
+        override suspend fun markUpdateSeen() = Unit
+    }
+
+    private class FakeDescriptorQrScanner : DescriptorQrScanner {
+        override fun ingest(raw: String): DescriptorScanState = DescriptorScanState.Idle
+        override fun reset() = Unit
+    }
+
+    private companion object {
+        const val DESCRIPTOR =
+            "wpkh([73c5da0a/84h/1h/0h]tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LgAFKvDsdsBPzMw3RGYbjeMs9dGcTLeUw6f7c/0/*)"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 coroutinesTest = "1.9.0"
+mockito = "5.14.2"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.03.01"
@@ -37,6 +38,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }

--- a/journeys/README.md
+++ b/journeys/README.md
@@ -122,8 +122,14 @@ action) on open. The snackbar is part of the Scaffold subtree, so its text and a
 | `input_descriptor`          | wallet descriptor field                |
 | `button_update_descriptor`  | "Update descriptor"                    |
 | `button_scan_descriptor`    | "Scan QR" (opens the descriptor scanner)|
+| `button_copy_descriptor`    | a loaded descriptor row — tap to copy the full descriptor to the clipboard |
 | `input_network`             | network selector field                 |
 | `toggle_mobile_data`        | "Also use mobile data" switch          |
+
+`button_copy_descriptor` is applied to each loaded descriptor row, so the tag repeats once
+per descriptor — target the first when more than one is present. Tapping a row copies the
+**full** descriptor (not the truncated two-line display) and shows a
+"Descriptor copied to clipboard" snackbar.
 
 `button_scan_descriptor` opens `DescriptorScanSheet` (a `ModalBottomSheet`) and, on a
 successful scan, `DescriptorScanConfirmDialog` (an `AlertDialog`). Both render in a

--- a/journeys/load_descriptor.xml
+++ b/journeys/load_descriptor.xml
@@ -1,7 +1,8 @@
 <journey name="Load descriptor">
     <description>
-        Pastes a wallet descriptor in Settings, submits it, and verifies the descriptor
-        list updates without the app crashing.
+        Pastes a wallet descriptor in Settings, submits it, verifies the descriptor list
+        updates, then copies the loaded descriptor back to the clipboard (issue #113), all
+        without the app crashing.
     </description>
     <actions>
         <action>Launch the Mandacaru app and wait for the splash screen to dismiss (poll until nav_node is present)</action>
@@ -11,5 +12,7 @@
         <action>Type "wpkh([73c5da0a/84h/1h/0h]tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LgAFKvDsdsBPzMw3RGYbjeMs9dGcTLeUw6f7c/0/*)" into the descriptor field (input_descriptor)</action>
         <action>Tap the Update descriptor button (button_update_descriptor)</action>
         <action>Verify the descriptors list shows the loaded descriptor or a confirmation, and the app has not crashed</action>
+        <action>Tap the loaded descriptor row (button_copy_descriptor; if more than one row is present, target the first) to copy it to the clipboard</action>
+        <action>Verify a "Descriptor copied to clipboard" snackbar appears (target by text) and the app has not crashed</action>
     </actions>
 </journey>


### PR DESCRIPTION
Closes #113.

## What

Makes the wallet descriptors listed under **Settings → Descriptors** copyable to the clipboard, so a user can lift a decoded descriptor straight out of Mandacaru and paste it elsewhere (Electrum's "Use a master key", Blue Wallet, etc.). This completes the scan-once-then-copy flow enabled by #65.

## Changes

- **UI** (`ScreenSettings.kt`): each descriptor row is now a clickable `Surface` with a trailing `Icons.Outlined.ContentCopy` icon, mirroring the existing Electrum node-address copy card. Tapping copies the **full** descriptor (the list still truncates the display to two lines) via `LocalClipboardManager` and shows a confirmation snackbar.
- **Action/VM** (`SettingsAction.kt`, `SettingsViewModel.kt`): copy is routed through a new `OnDescriptorCopied` action so the confirmation message lives in the ViewModel (reusing the existing `snackBarMessage` pipeline) and is unit-testable.
- **Tests**: new `SettingsViewModelTest` (JVM unit test) covers the copy confirmation and snackbar clearing. Adds `mockito-core` as a `testImplementation` to supply the `Context` the VM constructor requires (the repo has no other mocking lib).
- **Journeys**: documents the `button_copy_descriptor` testTag in `journeys/README.md` and extends `load_descriptor.xml` with a copy-and-verify step.

## Testing

- `./gradlew testDebugUnitTest` ✅
- `./gradlew detekt lintDebug` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)