### PR TITLE
fix: stop tablet dashboards from rendering on landscape phones

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -69,10 +68,10 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.window.core.layout.WindowSizeClass
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.BlockHeaderResult
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
+import com.github.jvsena42.mandacaru.presentation.utils.rememberAdaptiveLayout
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
@@ -121,20 +120,10 @@ fun ScreenBlockchainContent(
         },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->
-        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-        )
-        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-        )
-        val horizontalPadding = when {
-            isExpandedWidth -> 32.dp
-            isMediumOrWider -> 24.dp
-            else -> 16.dp
-        }
-        val maxContentWidth = if (isMediumOrWider) 1200.dp else 600.dp
-        val columns = if (isMediumOrWider) {
+        val layout = rememberAdaptiveLayout()
+        val horizontalPadding = layout.horizontalPadding
+        val maxContentWidth = layout.maxContentWidth
+        val columns = if (layout.isMediumOrWider) {
             StaggeredGridCells.Adaptive(minSize = 360.dp)
         } else {
             StaggeredGridCells.Fixed(1)
@@ -148,7 +137,7 @@ fun ScreenBlockchainContent(
                 .padding(contentPadding),
             contentAlignment = Alignment.TopCenter,
         ) {
-            if (isExpandedWidth) {
+            if (layout.useTwoPane) {
                 BlockchainTabletDashboard(
                     uiState = uiState,
                     onAction = onAction,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -64,7 +63,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowSizeClass
 import com.github.jvsena42.mandacaru.presentation.service.FlorestaService
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.ScreenBlockchain
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.ScreenNode
@@ -73,6 +71,7 @@ import com.github.jvsena42.mandacaru.presentation.ui.screens.splash.SplashScreen
 import com.github.jvsena42.mandacaru.presentation.ui.screens.transaction.ScreenTransaction
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.NotificationPermissionHelper
+import com.github.jvsena42.mandacaru.presentation.utils.rememberAdaptiveLayout
 import com.github.jvsena42.mandacaru.presentation.utils.restartApplication
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
@@ -256,10 +255,7 @@ private fun MainScreen(
         }
     }
 
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-    val useRail = windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-    )
+    val useRail = rememberAdaptiveLayout().useRail
     val onSelectDestination: (Int) -> Unit = { index ->
         coroutineScope.launch {
             pagerState.animateScrollToPage(index)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -72,7 +72,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -95,13 +94,13 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.window.core.layout.WindowSizeClass
 import java.text.NumberFormat
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 import com.github.jvsena42.mandacaru.presentation.ui.components.ExpandableHeader
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.RequestNotificationPermissions
+import com.github.jvsena42.mandacaru.presentation.utils.rememberAdaptiveLayout
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -181,26 +180,16 @@ fun ScreenNode(
         // Match the inner content's adaptive width/padding so the banner lines
         // up with the centered, width-capped layout on tablets instead of
         // spanning full-bleed above it.
-        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-        )
-        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-        )
-        val bannerHorizontalPadding = when {
-            isExpandedWidth -> 32.dp
-            isMediumOrWider -> 24.dp
-            else -> 16.dp
-        }
-        // The expanded (tablet) dashboard fills the full pager width, while the
+        val layout = rememberAdaptiveLayout()
+        val bannerHorizontalPadding = layout.horizontalPadding
+        // The two-pane (tablet) dashboard fills the full pager width, while the
         // compact/medium layouts cap and center their content; mirror that so the
         // banner always spans the same width as the content beneath it.
-        val bannerWidth = if (isExpandedWidth) {
+        val bannerWidth = if (layout.useTwoPane) {
             Modifier.fillMaxWidth()
         } else {
             Modifier
-                .widthIn(max = if (isMediumOrWider) 1200.dp else 600.dp)
+                .widthIn(max = layout.maxContentWidth)
                 .fillMaxWidth()
         }
         Column(
@@ -344,20 +333,10 @@ fun ScreenNode(
         onDismissExportQrSheet = onDismissExportQrSheet,
     )
 
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-    val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-    )
-    val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-    )
-    val horizontalPadding = when {
-        isExpandedWidth -> 32.dp
-        isMediumOrWider -> 24.dp
-        else -> 16.dp
-    }
-    val maxContentWidth = if (isMediumOrWider) 1200.dp else 600.dp
-    val columns = if (isMediumOrWider) {
+    val layout = rememberAdaptiveLayout()
+    val horizontalPadding = layout.horizontalPadding
+    val maxContentWidth = layout.maxContentWidth
+    val columns = if (layout.isMediumOrWider) {
         StaggeredGridCells.Adaptive(minSize = 360.dp)
     } else {
         StaggeredGridCells.Fixed(1)
@@ -370,7 +349,7 @@ fun ScreenNode(
             .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.TopCenter,
     ) {
-        if (isExpandedWidth) {
+        if (layout.useTwoPane) {
             TabletNodeDashboard(
                 uiState = uiState,
                 isHeaderSync = isHeaderSync,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -57,7 +57,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -97,7 +96,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowSizeClass
 import com.florestad.Network
 import com.github.jvsena42.mandacaru.BuildConfig
 import com.github.jvsena42.mandacaru.R
@@ -106,6 +104,7 @@ import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
 import com.github.jvsena42.mandacaru.presentation.ui.components.ExpandableHeader
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
+import com.github.jvsena42.mandacaru.presentation.utils.rememberAdaptiveLayout
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import java.time.Year
@@ -182,20 +181,11 @@ private fun ScreenSettings(
         },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->
-        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-        )
-        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-        )
-        val horizontalPadding = when {
-            isExpandedWidth -> 32.dp
-            isMediumOrWider -> 24.dp
-            else -> 16.dp
-        }
-        val maxContentWidth = if (isMediumOrWider) 1200.dp else 600.dp
-        val columns = if (isMediumOrWider) {
+        val layout = rememberAdaptiveLayout()
+        val isExpandedWidth = layout.isExpandedWidth
+        val horizontalPadding = layout.horizontalPadding
+        val maxContentWidth = layout.maxContentWidth
+        val columns = if (layout.isMediumOrWider) {
             StaggeredGridCells.Adaptive(minSize = 360.dp)
         } else {
             StaggeredGridCells.Fixed(1)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/ScreenTransaction.kt
@@ -52,7 +52,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarVisuals
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -77,11 +76,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.widthIn
-import androidx.window.core.layout.WindowSizeClass
 import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetTransactionResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.TransactionResult
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
+import com.github.jvsena42.mandacaru.presentation.utils.rememberAdaptiveLayout
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import java.text.SimpleDateFormat
@@ -160,19 +159,9 @@ fun ScreenTransactionContent(
         },
         contentWindowInsets = WindowInsets(0),
     ) { contentPadding ->
-        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
-        )
-        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-        )
-        val horizontalPadding = when {
-            isExpandedWidth -> 32.dp
-            isMediumOrWider -> 24.dp
-            else -> 16.dp
-        }
-        val maxContentWidth = if (isMediumOrWider) 1200.dp else 600.dp
+        val layout = rememberAdaptiveLayout()
+        val horizontalPadding = layout.horizontalPadding
+        val maxContentWidth = layout.maxContentWidth
 
         Box(
             modifier = Modifier
@@ -181,7 +170,7 @@ fun ScreenTransactionContent(
                 .padding(contentPadding),
             contentAlignment = Alignment.TopCenter,
         ) {
-            if (isExpandedWidth) {
+            if (layout.useTwoPane) {
                 TransactionTabletDashboard(
                     uiState = uiState,
                     onAction = onAction,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/AdaptiveLayout.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/AdaptiveLayout.kt
@@ -1,0 +1,45 @@
+package com.github.jvsena42.mandacaru.presentation.utils
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
+
+data class AdaptiveLayout(
+    val isMediumOrWider: Boolean,
+    val isExpandedWidth: Boolean,
+    val useRail: Boolean,
+    val useTwoPane: Boolean,
+    val horizontalPadding: Dp,
+    val maxContentWidth: Dp,
+)
+
+@Composable
+fun rememberAdaptiveLayout(): AdaptiveLayout {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    return remember(windowSizeClass) {
+        val isMediumOrWider = windowSizeClass.isWidthAtLeastBreakpoint(
+            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND
+        )
+        val isExpandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(
+            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
+        )
+        val isMediumHeightOrTaller = windowSizeClass.isHeightAtLeastBreakpoint(
+            WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND
+        )
+        AdaptiveLayout(
+            isMediumOrWider = isMediumOrWider,
+            isExpandedWidth = isExpandedWidth,
+            useRail = isMediumOrWider,
+            useTwoPane = isExpandedWidth && isMediumHeightOrTaller,
+            horizontalPadding = when {
+                isExpandedWidth -> 32.dp
+                isMediumOrWider -> 24.dp
+                else -> 16.dp
+            },
+            maxContentWidth = if (isMediumOrWider) 1200.dp else 600.dp,
+        )
+    }
+}


### PR DESCRIPTION
## Problem

On a phone in landscape (e.g. the test device: 1080×2400 @ 440dpi → **~873dp wide × ~393dp tall**), the **tablet two-pane dashboards** were rendering even though there's no vertical room, breaking the layout.

Root cause: every screen gated its tablet dashboard on **width only**:

```kotlin
if (windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND /* 840dp */)) { TabletDashboard(...) }
```

A landscape phone is ~873dp wide, so it crossed the 840dp expanded bound and got the full tablet UI. This is the multi-size best-practice gap: an expanded/two-pane layout must require enough **width AND height**.

## Fix

A two-pane layout now requires **width ≥ 840dp AND height ≥ 480dp** (`HEIGHT_DP_MEDIUM_LOWER_BOUND`):

- **Landscape phone** (873×393): width expanded but height < 480 → `useTwoPane = false` → scrollable grid content.
- **Tablet landscape** (e.g. 1280×800): both pass → dashboards kept.

The `NavigationRail` still appears at ≥ 600dp width, so landscape phones **keep the rail** (Material 3's recommended pattern for wide layouts) and only lose the cramped two-pane content.

The size-class logic — previously duplicated across 4 screens + `MainActivity` — is centralized in a new `rememberAdaptiveLayout()` helper exposing `useRail` / `useTwoPane` / `horizontalPadding` / `maxContentWidth`.

## Changes

- **New** `presentation/utils/AdaptiveLayout.kt`
- `MainActivity.kt` — `useRail` from the helper (behavior unchanged)
- `ScreenNode.kt` / `ScreenTransaction.kt` / `ScreenBlockchain.kt` — dashboard gate `isExpandedWidth` → `layout.useTwoPane`; Node's WiFi banner mirrors `useTwoPane` to stay width-aligned with content
- `ScreenSettings.kt` — no dashboard; routed through the helper (no behavior change)

## Verification

- `./gradlew assembleDebug` ✅
- `./gradlew detekt` ✅
- `./gradlew lintDebug` ✅
- On-device landscape check pending (device's MIUI "Install via USB" guard blocked install during development). The `@Preview(name = "Tablet landscape", widthDp = 1280, heightDp = 840)` previews still render the dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)