### PR TITLE
feat: in-app log viewer behind Advanced Features toggle (#43)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.compose.navigation)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
     implementation(libs.gson)
     implementation(libs.jna) { artifact { type = "aar" } }
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/MandacaruApplication.kt
@@ -25,6 +25,7 @@ import com.github.jvsena42.mandacaru.domain.scan.DescriptorQrScanner
 import com.github.jvsena42.mandacaru.domain.scan.QrTransactionScanner
 import com.github.jvsena42.mandacaru.domain.scan.TransactionDecoder
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.BlockchainViewModel
+import com.github.jvsena42.mandacaru.presentation.ui.screens.logs.DeveloperLogsViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.main.MainViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.NodeViewModel
 import com.github.jvsena42.mandacaru.presentation.ui.screens.transaction.TransactionViewModel
@@ -84,6 +85,7 @@ val presentationModule = module {
         )
     }
     viewModel { MainViewModel(appUpdateRepository = get()) }
+    viewModel { DeveloperLogsViewModel(context = androidContext()) }
     viewModel {
         TransactionViewModel(
             florestaRpc = get(),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/PreferenceKeys.kt
@@ -13,5 +13,6 @@ enum class PreferenceKeys(val dataStoreKey: Preferences.Key<String>) {
     UPDATE_LATEST_VERSION(stringPreferencesKey("UPDATE_LATEST_VERSION")),
     UPDATE_LATEST_APK_URL(stringPreferencesKey("UPDATE_LATEST_APK_URL")),
     UPDATE_SEEN_VERSION(stringPreferencesKey("UPDATE_SEEN_VERSION")),
-    USE_ALSO_MOBILE_DATA(stringPreferencesKey("USE_ALSO_MOBILE_DATA"))
+    USE_ALSO_MOBILE_DATA(stringPreferencesKey("USE_ALSO_MOBILE_DATA")),
+    ENABLE_ADVANCED_FEATURES(stringPreferencesKey("ENABLE_ADVANCED_FEATURES"))
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsEvents.kt
@@ -1,0 +1,7 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import android.net.Uri
+
+sealed interface DeveloperLogsEvents {
+    data class ShareLogs(val uri: Uri) : DeveloperLogsEvents
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsUiState.kt
@@ -1,0 +1,10 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import androidx.compose.runtime.Stable
+
+@Stable
+data class DeveloperLogsUiState(
+    val lines: List<LogLine> = emptyList(),
+    val isLoading: Boolean = true,
+    val snackBarMessage: String = "",
+)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/DeveloperLogsViewModel.kt
@@ -1,0 +1,91 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.core.content.FileProvider
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
+import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.File
+
+class DeveloperLogsViewModel(
+    @field:SuppressLint("StaticFieldLeak") private val context: Context,
+) : ViewModel(), EventFlow<DeveloperLogsEvents> by EventFlowImpl() {
+
+    private val _uiState = MutableStateFlow(DeveloperLogsUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private var pollJob: Job? = null
+
+    init {
+        observeLogs()
+    }
+
+    private fun observeLogs() {
+        pollJob?.cancel()
+        pollJob = viewModelScope.launch(Dispatchers.IO) {
+            while (true) {
+                val logFile = File(context.filesDir, LOG_FILE_NAME)
+                val lines = if (logFile.exists()) {
+                    LogParser.parse(LogTailReader.tail(logFile.readLines()).joinToString("\n"))
+                } else {
+                    emptyList()
+                }
+                _uiState.update { it.copy(lines = lines, isLoading = false) }
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    fun copiedToClipboard() {
+        _uiState.update {
+            it.copy(snackBarMessage = context.getString(R.string.logs_copied_to_clipboard))
+        }
+    }
+
+    fun clearSnackBarMessage() {
+        _uiState.update { it.copy(snackBarMessage = "") }
+    }
+
+    fun share() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val logFile = File(context.filesDir, LOG_FILE_NAME)
+            if (!logFile.exists()) {
+                _uiState.update {
+                    it.copy(snackBarMessage = context.getString(R.string.log_file_not_found))
+                }
+                return@launch
+            }
+
+            val cacheDir = File(context.cacheDir, "logs").apply { mkdirs() }
+            val cachedLog = File(cacheDir, LOG_FILE_NAME)
+            logFile.copyTo(cachedLog, overwrite = true)
+
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                cachedLog
+            )
+            viewModelScope.sendEvent(DeveloperLogsEvents.ShareLogs(uri))
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        pollJob?.cancel()
+    }
+
+    private companion object {
+        const val LOG_FILE_NAME = "debug.log"
+        const val POLL_INTERVAL_MS = 1500L
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogLine.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogLine.kt
@@ -1,0 +1,15 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+enum class LogLevel {
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
+    NONE,
+}
+
+data class LogLine(
+    val text: String,
+    val level: LogLevel,
+)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogParser.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogParser.kt
@@ -1,0 +1,20 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+object LogParser {
+
+    private val LEVEL_REGEX = Regex(
+        """^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\s+(ERROR|WARN|INFO|DEBUG|TRACE)\b"""
+    )
+
+    fun parse(raw: String): List<LogLine> {
+        if (raw.isEmpty()) return emptyList()
+        var previousLevel = LogLevel.NONE
+        return raw.lineSequence().map { line ->
+            val level = LEVEL_REGEX.find(line)?.let { match ->
+                LogLevel.valueOf(match.groupValues[1])
+            } ?: previousLevel
+            previousLevel = level
+            LogLine(text = line, level = level)
+        }.toList()
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogTailReader.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogTailReader.kt
@@ -1,0 +1,10 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+object LogTailReader {
+
+    const val DEFAULT_MAX_LINES = 1000
+
+    fun tail(lines: List<String>, max: Int = DEFAULT_MAX_LINES): List<String> {
+        return if (lines.size <= max) lines else lines.takeLast(max)
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/ScreenDeveloperLogs.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/ScreenDeveloperLogs.kt
@@ -1,0 +1,217 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScreenDeveloperLogs(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: DeveloperLogsViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
+    val shareLogsTitle = stringResource(R.string.share_logs)
+
+    LaunchedEffect(viewModel.eventFlow) {
+        viewModel.eventFlow.collect { event ->
+            when (event) {
+                is DeveloperLogsEvents.ShareLogs -> {
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_STREAM, event.uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, shareLogsTitle))
+                }
+            }
+        }
+    }
+
+    ScreenDeveloperLogs(
+        uiState = uiState,
+        onBack = onBack,
+        onCopy = {
+            clipboardManager.setText(AnnotatedString(uiState.lines.joinToString("\n") { it.text }))
+            viewModel.copiedToClipboard()
+        },
+        onShare = viewModel::share,
+        onSnackBarShown = viewModel::clearSnackBarMessage,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScreenDeveloperLogs(
+    uiState: DeveloperLogsUiState,
+    onBack: () -> Unit,
+    onCopy: () -> Unit,
+    onShare: () -> Unit,
+    onSnackBarShown: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackBarHostState = remember { SnackbarHostState() }
+    val currentOnSnackBarShown by rememberUpdatedState(onSnackBarShown)
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(uiState.snackBarMessage) {
+        if (uiState.snackBarMessage.isNotEmpty()) {
+            snackBarHostState.showSnackbar(uiState.snackBarMessage)
+            currentOnSnackBarShown()
+        }
+    }
+
+    // Keep the newest line in view as logs stream in, but only while the user is
+    // already at the bottom — `layoutInfo` here still reflects the pre-update
+    // layout, so it tells us whether they were following the tail.
+    LaunchedEffect(uiState.lines) {
+        val lines = uiState.lines
+        if (lines.isEmpty()) return@LaunchedEffect
+        val info = listState.layoutInfo
+        val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+        val wasAtBottom = lastVisible == -1 || lastVisible >= info.totalItemsCount - 1
+        if (wasAtBottom) listState.scrollToItem(lines.lastIndex)
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.logs)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("button_back_logs"),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.logs_back),
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = onCopy,
+                        enabled = uiState.lines.isNotEmpty(),
+                        modifier = Modifier.testTag("button_copy_logs"),
+                    ) {
+                        Icon(
+                            Icons.Outlined.ContentCopy,
+                            contentDescription = stringResource(R.string.copy_logs),
+                        )
+                    }
+                    IconButton(
+                        onClick = onShare,
+                        enabled = uiState.lines.isNotEmpty(),
+                        modifier = Modifier.testTag("button_export_logs"),
+                    ) {
+                        Icon(
+                            Icons.Outlined.Share,
+                            contentDescription = stringResource(R.string.share_logs),
+                        )
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .background(MaterialTheme.colorScheme.surface),
+            contentAlignment = Alignment.Center,
+        ) {
+            when {
+                uiState.isLoading -> CircularProgressIndicator()
+                uiState.lines.isEmpty() -> Text(
+                    text = stringResource(R.string.no_logs_available),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                else -> LogList(lines = uiState.lines, listState = listState)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogList(lines: List<LogLine>, listState: LazyListState) {
+    val horizontalScroll = rememberScrollState()
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(12.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        items(lines) { line ->
+            Text(
+                text = line.text,
+                color = line.level.color(),
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                softWrap = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(horizontalScroll),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LogLevel.color(): Color = when (this) {
+    LogLevel.ERROR -> Color(0xFFFF5370)
+    LogLevel.WARN -> Color(0xFFFFCB6B)
+    LogLevel.INFO -> Color(0xFFC3E88D)
+    LogLevel.DEBUG -> Color(0xFF82AAFF)
+    LogLevel.TRACE -> Color(0xFFC792EA)
+    LogLevel.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/AppRoute.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/AppRoute.kt
@@ -1,0 +1,6 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.main
+
+sealed interface AppRoute {
+    data object Home : AppRoute
+    data object DeveloperLogs : AppRoute
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainActivity.kt
@@ -63,8 +63,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
 import com.github.jvsena42.mandacaru.presentation.service.FlorestaService
 import com.github.jvsena42.mandacaru.presentation.ui.screens.blockchain.ScreenBlockchain
+import com.github.jvsena42.mandacaru.presentation.ui.screens.logs.ScreenDeveloperLogs
 import com.github.jvsena42.mandacaru.presentation.ui.screens.node.ScreenNode
 import com.github.jvsena42.mandacaru.presentation.ui.screens.settings.ScreenSettings
 import com.github.jvsena42.mandacaru.presentation.ui.screens.splash.SplashScreen
@@ -198,14 +201,34 @@ private fun MandacaruRoot(
             .fillMaxSize()
             .semantics { testTagsAsResourceId = true }
     ) {
-        MainScreen(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
-            restartApplication = restartApplication,
-            requestNotificationPermission = requestNotificationPermission,
-            hasNotificationPermission = hasNotificationPermission,
-            isSettingsBadgeVisible = isUpdateBadgeVisible,
+        NavDisplay(
+            backStack = mainViewModel.backStack,
+            onBack = { if (mainViewModel.backStack.size > 1) mainViewModel.navigateBack() },
+            entryProvider = { route ->
+                when (route) {
+                    AppRoute.Home -> NavEntry(route) {
+                        MainScreen(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.background),
+                            restartApplication = restartApplication,
+                            requestNotificationPermission = requestNotificationPermission,
+                            hasNotificationPermission = hasNotificationPermission,
+                            isSettingsBadgeVisible = isUpdateBadgeVisible,
+                            onOpenLogs = { mainViewModel.navigateTo(AppRoute.DeveloperLogs) },
+                        )
+                    }
+
+                    AppRoute.DeveloperLogs -> NavEntry(route) {
+                        ScreenDeveloperLogs(
+                            onBack = { mainViewModel.navigateBack() },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.background),
+                        )
+                    }
+                }
+            },
         )
         AnimatedVisibility(
             visible = showSplash,
@@ -227,6 +250,7 @@ private fun MainScreen(
     requestNotificationPermission: () -> Unit = {},
     hasNotificationPermission: Boolean = true,
     isSettingsBadgeVisible: Boolean = false,
+    onOpenLogs: () -> Unit = {},
 ) {
     val pages = Destinations.entries
     val pagerState = rememberPagerState(
@@ -308,6 +332,7 @@ private fun MainScreen(
                     Destinations.SETTINGS -> ScreenSettings(
                         restartApplication = restartApplication,
                         bottomContentPadding = bottomBarPadding,
+                        onOpenLogs = onOpenLogs,
                     )
                 }
             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/main/MainViewModel.kt
@@ -1,5 +1,7 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.main
 
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.jvsena42.mandacaru.data.AppUpdateRepository
@@ -16,7 +18,17 @@ class MainViewModel(
         .map { it.isBadgeVisible }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+    val backStack: SnapshotStateList<AppRoute> = mutableStateListOf(AppRoute.Home)
+
     init {
         viewModelScope.launch { appUpdateRepository.refresh(force = true) }
+    }
+
+    fun navigateTo(route: AppRoute) {
+        if (backStack.lastOrNull() != route) backStack.add(route)
+    }
+
+    fun navigateBack() {
+        backStack.removeLastOrNull()
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
@@ -115,10 +116,12 @@ fun ScreenSettings(
     restartApplication: () -> Unit,
     modifier: Modifier = Modifier,
     bottomContentPadding: Dp = 0.dp,
+    onOpenLogs: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val currentRestartApplication by rememberUpdatedState(restartApplication)
+    val currentOnOpenLogs by rememberUpdatedState(onOpenLogs)
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val shareLogsTitle = stringResource(R.string.share_logs)
@@ -145,6 +148,7 @@ fun ScreenSettings(
                     )
                 }
                 is SettingsEvents.OpenReleasePage -> uriHandler.openUri(event.url)
+                is SettingsEvents.OpenDeveloperLogs -> currentOnOpenLogs()
             }
         }
     }
@@ -718,56 +722,6 @@ private fun ScreenSettings(
                     }
                 }
 
-                // Export Logs
-                item {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .animateItem(),
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainer
-                        ),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp, vertical = 12.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Description,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                                Text(
-                                    stringResource(R.string.logs),
-                                    style = MaterialTheme.typography.titleSmall,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
-                            FilledTonalButton(
-                                onClick = { onAction(SettingsAction.OnClickExportLogs) },
-                                shape = RoundedCornerShape(12.dp)
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Share,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.size(8.dp))
-                                Text(stringResource(R.string.export_logs))
-                            }
-                        }
-                    }
-                }
-
                 // Donate Section
                 item {
                     val clipboardManager = LocalClipboardManager.current
@@ -881,6 +835,97 @@ private fun ScreenSettings(
                                 updateStatus = uiState.updateStatus,
                                 onAction = onAction,
                             )
+                        }
+                    }
+                }
+
+                // Advanced Features toggle
+                item {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateItem(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainer
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.advanced_features),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                                Text(
+                                    text = stringResource(R.string.advanced_features_subtitle),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Switch(
+                                checked = uiState.enableAdvancedFeatures,
+                                onCheckedChange = {
+                                    onAction(SettingsAction.OnToggleAdvancedFeatures(it))
+                                },
+                                modifier = Modifier
+                                    .padding(start = 12.dp)
+                                    .testTag("toggle_advanced_features"),
+                            )
+                        }
+                    }
+                }
+
+                // Developer Tools Section
+                if (uiState.enableAdvancedFeatures) {
+                    item {
+                        SectionCard(
+                            title = stringResource(R.string.developer_tools),
+                            icon = Icons.Outlined.Code,
+                            isExpanded = uiState.isDeveloperToolsExpanded,
+                            onToggle = { onAction(SettingsAction.ToggleDeveloperToolsExpanded) },
+                            modifier = Modifier.animateItem(),
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                Button(
+                                    onClick = { onAction(SettingsAction.OnClickViewLogs) },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("button_view_logs"),
+                                    shape = RoundedCornerShape(12.dp),
+                                ) {
+                                    Icon(
+                                        Icons.Outlined.Description,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                    Spacer(modifier = Modifier.size(8.dp))
+                                    Text(stringResource(R.string.view_logs))
+                                }
+
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                FilledTonalButton(
+                                    onClick = { onAction(SettingsAction.OnClickExportLogs) },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("button_export_logs"),
+                                    shape = RoundedCornerShape(12.dp),
+                                ) {
+                                    Icon(
+                                        Icons.Outlined.Share,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                    Spacer(modifier = Modifier.size(8.dp))
+                                    Text(stringResource(R.string.export_logs))
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -32,4 +32,7 @@ sealed interface SettingsAction {
     object OnCancelBirthdayRestart: SettingsAction
     object ToggleDataUsageExpanded: SettingsAction
     data class OnToggleMobileData(val enabled: Boolean): SettingsAction
+    data class OnToggleAdvancedFeatures(val enabled: Boolean): SettingsAction
+    object ToggleDeveloperToolsExpanded: SettingsAction
+    object OnClickViewLogs: SettingsAction
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsEvents.kt
@@ -6,4 +6,5 @@ sealed interface SettingsEvents {
     data object OnBirthdayChanged : SettingsEvents
     data class OnExportLogs(val uri: android.net.Uri) : SettingsEvents
     data class OpenReleasePage(val url: String) : SettingsEvents
+    data object OpenDeveloperLogs : SettingsEvents
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -42,4 +42,6 @@ data class SettingsUiState(
     val rescanBlocksTotal: Int? = null,
     val useAlsoMobileData: Boolean = false,
     val isDataUsageExpanded: Boolean = false,
+    val enableAdvancedFeatures: Boolean = false,
+    val isDeveloperToolsExpanded: Boolean = false,
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -61,6 +61,8 @@ class SettingsViewModel(
                 ?: WalletBirthday.defaultYear()
             val useAlsoMobileData = preferencesDataSource
                 .getBoolean(PreferenceKeys.USE_ALSO_MOBILE_DATA, false)
+            val enableAdvancedFeatures = preferencesDataSource
+                .getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, false)
             _uiState.update {
                 it.copy(
                     selectedNetwork = preferencesDataSource.getString(
@@ -69,6 +71,7 @@ class SettingsViewModel(
                     ),
                     walletBirthdayYear = birthdayYear,
                     useAlsoMobileData = useAlsoMobileData,
+                    enableAdvancedFeatures = enableAdvancedFeatures,
                 )
             }
             updateElectrumAddress()
@@ -204,6 +207,29 @@ class SettingsViewModel(
             SettingsAction.OnConfirmBirthdayRestart -> applyBirthdayYearAndRestart()
             SettingsAction.ToggleDataUsageExpanded -> toggleDataUsageExpanded()
             is SettingsAction.OnToggleMobileData -> handleMobileDataToggled(action)
+            is SettingsAction.OnToggleAdvancedFeatures -> handleAdvancedFeaturesToggled(action)
+            SettingsAction.ToggleDeveloperToolsExpanded -> _uiState.update {
+                it.copy(isDeveloperToolsExpanded = !it.isDeveloperToolsExpanded)
+            }
+
+            SettingsAction.OnClickViewLogs -> viewModelScope.sendEvent(
+                SettingsEvents.OpenDeveloperLogs
+            )
+        }
+    }
+
+    private fun handleAdvancedFeaturesToggled(action: SettingsAction.OnToggleAdvancedFeatures) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesDataSource.setBoolean(
+                PreferenceKeys.ENABLE_ADVANCED_FEATURES,
+                action.enabled
+            )
+            _uiState.update {
+                it.copy(
+                    enableAdvancedFeatures = action.enabled,
+                    isDeveloperToolsExpanded = action.enabled && it.isDeveloperToolsExpanded,
+                )
+            }
         }
     }
 
@@ -498,7 +524,9 @@ class SettingsViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             val logFile = File(context.filesDir, "debug.log")
             if (!logFile.exists()) {
-                _uiState.update { it.copy(snackBarMessage = "Log file not found") }
+                _uiState.update {
+                    it.copy(snackBarMessage = context.getString(R.string.log_file_not_found))
+                }
                 return@launch
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,15 @@
     <string name="logs">Logs</string>
     <string name="export_logs">Export</string>
     <string name="share_logs">Share Logs</string>
+    <string name="advanced_features">Advanced features</string>
+    <string name="advanced_features_subtitle">Show developer tools such as the node log viewer</string>
+    <string name="developer_tools">Developer Tools</string>
+    <string name="view_logs">View logs</string>
+    <string name="copy_logs">Copy logs</string>
+    <string name="logs_copied_to_clipboard">Logs copied to clipboard</string>
+    <string name="no_logs_available">No logs available yet</string>
+    <string name="log_file_not_found">Log file not found</string>
+    <string name="logs_back">Back</string>
     <string name="utreexo_warning_title">No Utreexo peers connected</string>
     <string name="utreexo_warning_message">Sync requires a Utreexo peer. Connecting to known bridges…</string>
 

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogParserTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogParserTest.kt
@@ -1,0 +1,76 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LogParserTest {
+
+    @Test
+    fun `info line maps to INFO`() {
+        val result = LogParser.parse("2024-01-15 10:23:45  INFO floresta_wire::p2p_wire::peer: Handshake done")
+        assertEquals(1, result.size)
+        assertEquals(LogLevel.INFO, result.first().level)
+    }
+
+    @Test
+    fun `warn error debug trace lines map to their levels`() {
+        val raw = listOf(
+            "2024-01-15 10:23:45  WARN floresta_chain: low filters",
+            "2024-01-15 10:23:46 ERROR floresta_wire::transport: broken pipe",
+            "2024-01-15 10:23:47 DEBUG floresta_node: tick",
+            "2024-01-15 10:23:48 TRACE floresta_common: detail",
+        ).joinToString("\n")
+
+        val levels = LogParser.parse(raw).map { it.level }
+
+        assertEquals(
+            listOf(LogLevel.WARN, LogLevel.ERROR, LogLevel.DEBUG, LogLevel.TRACE),
+            levels,
+        )
+    }
+
+    @Test
+    fun `level token padded with extra spaces is still parsed`() {
+        val result = LogParser.parse("2024-01-15 10:23:45     INFO target: msg")
+        assertEquals(LogLevel.INFO, result.first().level)
+    }
+
+    @Test
+    fun `continuation lines inherit the previous level`() {
+        val raw = listOf(
+            "2024-01-15 10:23:45 ERROR floresta_wire::transport: panic backtrace:",
+            "    at frame 0",
+            "    at frame 1",
+        ).joinToString("\n")
+
+        val result = LogParser.parse(raw)
+
+        assertEquals(LogLevel.ERROR, result[0].level)
+        assertEquals(LogLevel.ERROR, result[1].level)
+        assertEquals(LogLevel.ERROR, result[2].level)
+    }
+
+    @Test
+    fun `leading text before any log line is NONE`() {
+        val result = LogParser.parse("some preamble without a timestamp")
+        assertEquals(LogLevel.NONE, result.first().level)
+    }
+
+    @Test
+    fun `full line text is preserved`() {
+        val line = "2024-01-15 10:23:45  INFO floresta_wire::p2p_wire::peer: Handshake completed peer=3"
+        val result = LogParser.parse(line)
+        assertEquals(line, result.first().text)
+    }
+
+    @Test
+    fun `empty input yields empty list`() {
+        assertEquals(emptyList<LogLine>(), LogParser.parse(""))
+    }
+
+    @Test
+    fun `a word matching a level inside the message does not change the level`() {
+        val result = LogParser.parse("2024-01-15 10:23:45  INFO node: retry after ERROR response")
+        assertEquals(LogLevel.INFO, result.first().level)
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogTailReaderTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/logs/LogTailReaderTest.kt
@@ -1,0 +1,31 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.logs
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LogTailReaderTest {
+
+    @Test
+    fun `fewer lines than max returns all lines`() {
+        val lines = listOf("a", "b", "c")
+        assertEquals(lines, LogTailReader.tail(lines, max = 10))
+    }
+
+    @Test
+    fun `more lines than max returns exactly the last max`() {
+        val lines = (1..100).map { it.toString() }
+        val result = LogTailReader.tail(lines, max = 10)
+        assertEquals((91..100).map { it.toString() }, result)
+    }
+
+    @Test
+    fun `exactly max returns all lines`() {
+        val lines = (1..10).map { it.toString() }
+        assertEquals(lines, LogTailReader.tail(lines, max = 10))
+    }
+
+    @Test
+    fun `empty input returns empty`() {
+        assertEquals(emptyList<String>(), LogTailReader.tail(emptyList(), max = 10))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ material3Adaptive = "1.2.0"
 koin-bom = "4.2.0"
 materialIconsExtended = "1.7.8"
 nav-version = "2.9.7"
+nav3Core = "1.1.2"
 okhttp = "5.3.2"
 jetbrainsKotlinJvm = "2.3.20"
 datastorePreferences = "1.2.1"
@@ -53,6 +54,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material3-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "material3Adaptive" }
 compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "nav-version" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "nav3Core" }
+androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "nav3Core" }
 
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-core = { module = "io.insert-koin:koin-core" }

--- a/journeys/README.md
+++ b/journeys/README.md
@@ -125,6 +125,9 @@ action) on open. The snackbar is part of the Scaffold subtree, so its text and a
 | `button_copy_descriptor`    | a loaded descriptor row — tap to copy the full descriptor to the clipboard |
 | `input_network`             | network selector field                 |
 | `toggle_mobile_data`        | "Also use mobile data" switch          |
+| `toggle_advanced_features`  | "Advanced features" switch (gates the Developer Tools section) |
+| `button_view_logs`          | "View logs" (opens the full-screen log viewer) |
+| `button_export_logs`        | "Export" (share the full debug.log) — inside Developer Tools |
 
 `button_copy_descriptor` is applied to each loaded descriptor row, so the tag repeats once
 per descriptor — target the first when more than one is present. Tapping a row copies the
@@ -140,6 +143,14 @@ separate window (per the popup caveat below), so their controls — "Paste inste
 The Data usage section's `toggle_mobile_data` switch is off by default (Wi-Fi only);
 turning it on persists the preference and restarts the app. Expand the "Data usage"
 section by text before asserting on it.
+
+`toggle_advanced_features` is off by default. The **Developer Tools** section (and its
+`button_view_logs` / `button_export_logs`) only renders once the toggle is on. Expand
+"Developer Tools" by text, then tap `button_view_logs` to open `ScreenDeveloperLogs` — a
+full-screen Nav3 destination in the root subtree, so its tags surface normally (the popup
+caveat does **not** apply). There: `button_back_logs` returns to Settings, `button_copy_logs`
+copies the displayed tail, and the share action reuses `button_export_logs`. Each log line
+is colored by level (ERROR/WARN/INFO/DEBUG/TRACE).
 
 Tapping `input_network` opens the network dropdown. Its options are **targeted by text**
 (`BITCOIN`, `SIGNET`, `TESTNET`, `REGTEST`, `TESTNET4`) — see the popup caveat below.


### PR DESCRIPTION
## What

Implements issue #43 (read & copy node logs in-app) behind a master **Advanced Features** switch in Settings. When enabled, a new **Developer Tools** section appears with an in-app, color-coded log viewer; the existing Export/Share logs action moves into that section.

## Changes

- **Advanced Features toggle** — persisted `ENABLE_ADVANCED_FEATURES` preference (off by default, no app restart). Placed last in the Settings list.
- **Developer Tools section** — gated by the toggle; contains **View logs** + the relocated **Export**.
- **Full-screen log viewer via Jetpack Navigation 3** — introduces a `NavDisplay` at `MainActivity` with a `Home` entry (existing pager/tabs, unchanged) and a pushed `DeveloperLogs` entry; back stack lives in `MainViewModel`, system/predictive back handled by Nav3 `onBack`. Adds `navigation3-runtime`/`-ui` `1.1.2`.
- **Color-coded, live tailing** — parses the daemon's `debug.log` (matches `floresta-node` `logging.rs` default `tracing` fmt, no ANSI), colors each line by level (ERROR/WARN/INFO/DEBUG/TRACE), tails the last ~1000 lines, polls every 1.5s, and follows the tail (auto-scroll to bottom) unless the user has scrolled up. Copy + Share supported.
- **Unit tests** — pure `LogParser` / `LogTailReader` helpers with `LogParserTest` (8) and `LogTailReaderTest` (4).
- **Docs** — `journeys/README.md` testTag contract updated (`toggle_advanced_features`, `button_view_logs`, `button_export_logs`, `button_copy_logs`, `button_back_logs`).

## Verification

- `./gradlew testDebugUnitTest assembleDebug detekt lintDebug` — all green.
- On-device manual verification (toggle persistence, live color rendering, scroll-follow) not yet run — no device was attached during development.

## Notes

- Nav3 is a new dependency (the app previously had no `NavHost`); blast radius is contained — the `Home` entry wraps the existing tab UI verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)