### PR TITLE
fix: release camera when QR scanner sheet closes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,11 @@ Mandacaru is an Android application that runs a lightweight Bitcoin validation n
 
 Lint configuration lives at `app/lint.xml`; detekt configuration lives at `config/detekt/detekt.yml`. When a rule fires on generated code or on an intentional project decision (e.g. ARM64-only build), prefer tuning the config over disabling the rule globally.
 
+### Kotlin Conventions
+
+- Prefer `runCatching { ... }` over `try`/`catch` for error handling. When the original code only swallowed a specific exception type, preserve that by re-throwing others in `onFailure` (e.g. `.onFailure { if (it !is IllegalStateException) throw it }`).
+- Import types and use the short name rather than fully-qualified names inline (e.g. import `androidx.annotation.OptIn` instead of writing `@androidx.annotation.OptIn(...)`). When the simple name collides with an auto-imported one (`androidx.annotation.OptIn` vs `kotlin.OptIn`), use an import alias (e.g. `import androidx.annotation.OptIn as AndroidXOptIn`).
+
 ### Development Setup
 - Requires Android 10 (API 29) minimum
 - ARM64 device only (arm64-v8a) - the Rust library is compiled for ARM64 only

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/components/QrCameraPreview.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/components/QrCameraPreview.kt
@@ -1,5 +1,6 @@
 package com.github.jvsena42.mandacaru.presentation.ui.components
 
+import androidx.annotation.OptIn as AndroidXOptIn
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
@@ -68,7 +69,7 @@ fun QrCameraPreview(
                 val provider = providerFuture.get()
                 cameraProvider.set(provider)
                 val preview = Preview.Builder().build().also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
+                    it.surfaceProvider = previewView.surfaceProvider
                 }
                 val analysis = ImageAnalysis.Builder()
                     .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
@@ -82,7 +83,7 @@ fun QrCameraPreview(
                             }
                         }
                     }
-                try {
+                runCatching {
                     provider.unbindAll()
                     provider.bindToLifecycle(
                         lifecycleOwner,
@@ -90,15 +91,14 @@ fun QrCameraPreview(
                         preview,
                         analysis,
                     )
-                } catch (_: IllegalStateException) {
-                }
+                }.onFailure { if (it !is IllegalStateException) throw it }
             }, ContextCompat.getMainExecutor(ctx))
             previewView
         },
     )
 }
 
-@androidx.annotation.OptIn(ExperimentalGetImage::class)
+@AndroidXOptIn(ExperimentalGetImage::class)
 private fun processFrame(
     proxy: ImageProxy,
     scanner: BarcodeScanner,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/components/QrCameraPreview.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/components/QrCameraPreview.kt
@@ -1,0 +1,118 @@
+package com.github.jvsena42.mandacaru.presentation.ui.components
+
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+
+@Composable
+fun QrCameraPreview(
+    enabled: Boolean,
+    onPayloadScanned: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lastPayload = remember { AtomicReference<String?>(null) }
+    val isEnabled = rememberUpdatedState(enabled)
+    val currentOnPayload = rememberUpdatedState(onPayloadScanned)
+    val cameraProvider = remember { AtomicReference<ProcessCameraProvider?>(null) }
+    val scanner = remember {
+        BarcodeScanning.getClient(
+            BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .build()
+        )
+    }
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+    LaunchedEffect(enabled) {
+        if (enabled) lastPayload.set(null)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            cameraProvider.get()?.unbindAll()
+            analysisExecutor.shutdown()
+            scanner.close()
+        }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            val previewView = PreviewView(ctx).apply {
+                scaleType = PreviewView.ScaleType.FILL_CENTER
+                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+            }
+            val providerFuture = ProcessCameraProvider.getInstance(ctx)
+            providerFuture.addListener({
+                val provider = providerFuture.get()
+                cameraProvider.set(provider)
+                val preview = Preview.Builder().build().also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+                val analysis = ImageAnalysis.Builder()
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .build()
+                    .also {
+                        it.setAnalyzer(analysisExecutor) { proxy ->
+                            processFrame(proxy, scanner) { payload ->
+                                if (isEnabled.value && lastPayload.getAndSet(payload) != payload) {
+                                    currentOnPayload.value(payload)
+                                }
+                            }
+                        }
+                    }
+                try {
+                    provider.unbindAll()
+                    provider.bindToLifecycle(
+                        lifecycleOwner,
+                        CameraSelector.DEFAULT_BACK_CAMERA,
+                        preview,
+                        analysis,
+                    )
+                } catch (_: IllegalStateException) {
+                }
+            }, ContextCompat.getMainExecutor(ctx))
+            previewView
+        },
+    )
+}
+
+@androidx.annotation.OptIn(ExperimentalGetImage::class)
+private fun processFrame(
+    proxy: ImageProxy,
+    scanner: BarcodeScanner,
+    onPayload: (String) -> Unit,
+) {
+    val mediaImage = proxy.image
+    if (mediaImage == null) {
+        proxy.close()
+        return
+    }
+    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
+    scanner.process(image)
+        .addOnSuccessListener { barcodes ->
+            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
+        }
+        .addOnCompleteListener { proxy.close() }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/UtreexoScanSheet.kt
@@ -3,12 +3,6 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,18 +36,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.components.QrCameraPreview
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
-import com.google.mlkit.vision.barcode.BarcodeScanner
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
-import java.util.concurrent.Executors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -64,6 +50,7 @@ fun UtreexoScanSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var hasCamera by remember { mutableStateOf(false) }
+    var alreadyFired by remember { mutableStateOf(false) }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -88,8 +75,14 @@ fun UtreexoScanSheet(
                         .weight(1f),
                     contentAlignment = Alignment.Center,
                 ) {
-                    CameraPreview(
-                        onPayloadScanned = onPayloadScanned,
+                    QrCameraPreview(
+                        enabled = !alreadyFired,
+                        onPayloadScanned = {
+                            if (!alreadyFired) {
+                                alreadyFired = true
+                                onPayloadScanned(it)
+                            }
+                        },
                         modifier = Modifier
                             .fillMaxSize()
                             .clip(RoundedCornerShape(16.dp)),
@@ -106,83 +99,6 @@ fun UtreexoScanSheet(
             }
         }
     }
-}
-
-@Composable
-private fun CameraPreview(
-    onPayloadScanned: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-    var alreadyFired by remember { mutableStateOf(false) }
-    val scanner = remember {
-        BarcodeScanning.getClient(
-            BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build()
-        )
-    }
-    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
-
-    AndroidView(
-        modifier = modifier,
-        factory = { ctx ->
-            val previewView = PreviewView(ctx).apply {
-                scaleType = PreviewView.ScaleType.FILL_CENTER
-                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
-            }
-            val providerFuture = ProcessCameraProvider.getInstance(ctx)
-            providerFuture.addListener({
-                val provider = providerFuture.get()
-                val preview = androidx.camera.core.Preview.Builder().build().also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
-                }
-                val analysis = ImageAnalysis.Builder()
-                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                    .build()
-                    .also {
-                        it.setAnalyzer(analysisExecutor) { proxy ->
-                            processFrame(proxy, scanner) { payload ->
-                                if (!alreadyFired) {
-                                    alreadyFired = true
-                                    onPayloadScanned(payload)
-                                }
-                            }
-                        }
-                    }
-                try {
-                    provider.unbindAll()
-                    provider.bindToLifecycle(
-                        lifecycleOwner,
-                        CameraSelector.DEFAULT_BACK_CAMERA,
-                        preview,
-                        analysis,
-                    )
-                } catch (_: IllegalStateException) {
-                }
-            }, ContextCompat.getMainExecutor(ctx))
-            previewView
-        },
-    )
-}
-
-@androidx.annotation.OptIn(ExperimentalGetImage::class)
-private fun processFrame(
-    proxy: ImageProxy,
-    scanner: BarcodeScanner,
-    onPayload: (String) -> Unit,
-) {
-    val mediaImage = proxy.image
-    if (mediaImage == null) {
-        proxy.close()
-        return
-    }
-    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
-    scanner.process(image)
-        .addOnSuccessListener { barcodes ->
-            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
-        }
-        .addOnCompleteListener { proxy.close() }
 }
 
 @Composable

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorScanSheet.kt
@@ -3,12 +3,6 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,11 +28,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,18 +39,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.components.QrCameraPreview
 import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
-import com.google.mlkit.vision.barcode.BarcodeScanner
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -113,7 +96,7 @@ fun DescriptorScanSheet(
                                 .weight(1f),
                             contentAlignment = Alignment.Center,
                         ) {
-                            ContinuousCameraPreview(
+                            QrCameraPreview(
                                 enabled = error.isEmpty(),
                                 onPayloadScanned = onFrameScanned,
                                 modifier = Modifier
@@ -239,88 +222,6 @@ private fun CameraDeniedFallback() {
             Text(stringResource(R.string.open_app_settings))
         }
     }
-}
-
-@Composable
-private fun ContinuousCameraPreview(
-    enabled: Boolean,
-    onPayloadScanned: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val lastPayload = remember { AtomicReference<String?>(null) }
-    val isEnabled = rememberUpdatedState(enabled)
-    val scanner = remember {
-        BarcodeScanning.getClient(
-            BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build()
-        )
-    }
-    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
-
-    LaunchedEffect(enabled) {
-        if (enabled) lastPayload.set(null)
-    }
-
-    AndroidView(
-        modifier = modifier,
-        factory = { ctx ->
-            val previewView = PreviewView(ctx).apply {
-                scaleType = PreviewView.ScaleType.FILL_CENTER
-                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
-            }
-            val providerFuture = ProcessCameraProvider.getInstance(ctx)
-            providerFuture.addListener({
-                val provider = providerFuture.get()
-                val preview = androidx.camera.core.Preview.Builder().build().also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
-                }
-                val analysis = ImageAnalysis.Builder()
-                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                    .build()
-                    .also {
-                        it.setAnalyzer(analysisExecutor) { proxy ->
-                            processFrame(proxy, scanner) { payload ->
-                                if (isEnabled.value && lastPayload.getAndSet(payload) != payload) {
-                                    onPayloadScanned(payload)
-                                }
-                            }
-                        }
-                    }
-                try {
-                    provider.unbindAll()
-                    provider.bindToLifecycle(
-                        lifecycleOwner,
-                        CameraSelector.DEFAULT_BACK_CAMERA,
-                        preview,
-                        analysis,
-                    )
-                } catch (_: IllegalStateException) {
-                }
-            }, ContextCompat.getMainExecutor(ctx))
-            previewView
-        },
-    )
-}
-
-@androidx.annotation.OptIn(ExperimentalGetImage::class)
-private fun processFrame(
-    proxy: ImageProxy,
-    scanner: BarcodeScanner,
-    onPayload: (String) -> Unit,
-) {
-    val mediaImage = proxy.image
-    if (mediaImage == null) {
-        proxy.close()
-        return
-    }
-    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
-    scanner.process(image)
-        .addOnSuccessListener { barcodes ->
-            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
-        }
-        .addOnCompleteListener { proxy.close() }
 }
 
 private const val SHEET_HEIGHT_FRACTION = 0.92f

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/transaction/TransactionScanSheet.kt
@@ -3,12 +3,6 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.transaction
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,11 +29,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,18 +40,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.components.QrCameraPreview
 import com.github.jvsena42.mandacaru.presentation.utils.RequestCameraPermission
-import com.google.mlkit.vision.barcode.BarcodeScanner
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -115,7 +98,7 @@ fun TransactionScanSheet(
                                 .weight(1f),
                             contentAlignment = Alignment.Center,
                         ) {
-                            ContinuousCameraPreview(
+                            QrCameraPreview(
                                 enabled = uiState.scanError.isEmpty() && !uiState.isDecoding,
                                 onPayloadScanned = { onAction(TransactionAction.OnQrFrameScanned(it)) },
                                 modifier = Modifier
@@ -258,88 +241,6 @@ private fun CameraDeniedFallback() {
             Text(stringResource(R.string.open_app_settings))
         }
     }
-}
-
-@Composable
-private fun ContinuousCameraPreview(
-    enabled: Boolean,
-    onPayloadScanned: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val lastPayload = remember { AtomicReference<String?>(null) }
-    val isEnabled = rememberUpdatedState(enabled)
-    val scanner = remember {
-        BarcodeScanning.getClient(
-            BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build()
-        )
-    }
-    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
-
-    LaunchedEffect(enabled) {
-        if (enabled) lastPayload.set(null)
-    }
-
-    AndroidView(
-        modifier = modifier,
-        factory = { ctx ->
-            val previewView = PreviewView(ctx).apply {
-                scaleType = PreviewView.ScaleType.FILL_CENTER
-                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
-            }
-            val providerFuture = ProcessCameraProvider.getInstance(ctx)
-            providerFuture.addListener({
-                val provider = providerFuture.get()
-                val preview = androidx.camera.core.Preview.Builder().build().also {
-                    it.setSurfaceProvider(previewView.surfaceProvider)
-                }
-                val analysis = ImageAnalysis.Builder()
-                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                    .build()
-                    .also {
-                        it.setAnalyzer(analysisExecutor) { proxy ->
-                            processFrame(proxy, scanner) { payload ->
-                                if (isEnabled.value && lastPayload.getAndSet(payload) != payload) {
-                                    onPayloadScanned(payload)
-                                }
-                            }
-                        }
-                    }
-                try {
-                    provider.unbindAll()
-                    provider.bindToLifecycle(
-                        lifecycleOwner,
-                        CameraSelector.DEFAULT_BACK_CAMERA,
-                        preview,
-                        analysis,
-                    )
-                } catch (_: IllegalStateException) {
-                }
-            }, ContextCompat.getMainExecutor(ctx))
-            previewView
-        },
-    )
-}
-
-@androidx.annotation.OptIn(ExperimentalGetImage::class)
-private fun processFrame(
-    proxy: ImageProxy,
-    scanner: BarcodeScanner,
-    onPayload: (String) -> Unit,
-) {
-    val mediaImage = proxy.image
-    if (mediaImage == null) {
-        proxy.close()
-        return
-    }
-    val image = InputImage.fromMediaImage(mediaImage, proxy.imageInfo.rotationDegrees)
-    scanner.process(image)
-        .addOnSuccessListener { barcodes ->
-            barcodes.firstOrNull { it.rawValue != null }?.rawValue?.let(onPayload)
-        }
-        .addOnCompleteListener { proxy.close() }
 }
 
 private const val SHEET_HEIGHT_FRACTION = 0.92f


### PR DESCRIPTION
## Problem

Reported in [issue #65 comment](https://github.com/jvsena42/mandacaru/issues/65#issuecomment-4683314738): in v0.12 the Android green camera privacy indicator briefly flashes on **every app focus event** — cold launch, app switch, screen unlock — even though the user never tapped a "Scan QR" button.

## Root cause

All three QR-scanner preview composables (`UtreexoScanSheet`, `TransactionScanSheet`, `DescriptorScanSheet`) called `provider.bindToLifecycle(activityLifecycle, …)` inside the `AndroidView` factory but **never unbound** the CameraX use cases when the sheet was dismissed — `unbindAll()` only ran just before a re-bind. So once any scan sheet was opened during a session, the `Preview` + `ImageAnalysis` use cases stayed bound to the Activity lifecycle, and CameraX re-opened the camera on every `ON_START` (resume/unlock). The flash is short-lived because the `PreviewView` surface no longer exists, but it still counts as camera access. The `analysisExecutor` and ML Kit `BarcodeScanner` were also leaked (never `shutdown()`/`close()`).

## Fix

- Add a shared `QrCameraPreview` composable (`presentation/ui/components/QrCameraPreview.kt`) that owns the camera lifecycle and releases everything on dispose via `DisposableEffect`: `provider.unbindAll()`, `analysisExecutor.shutdown()`, `scanner.close()`.
- Replace the three near-identical local previews with it; lift the Utreexo single-shot dedupe into its caller (`enabled = !alreadyFired`).
- Net: removes ~296 lines of triplicated camera plumbing, fixes the leak in one place.

## Testing

- `./gradlew assembleDebug detekt lintDebug` — passes.
- Manual on-device verification (ARM64): open the descriptor scan sheet, close it, then background/unlock — the green camera indicator no longer flashes; scanning still decodes a descriptor end-to-end. Repeat for the transaction and Utreexo scanners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)