### PR TITLE
fix: move koin-test to testImplementation scope

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,10 +133,10 @@ dependencies {
     implementation(libs.koin.viewmodel)
     implementation(libs.koin.compose)
     implementation(libs.koin.android)
-    implementation(libs.koin.test)
     implementation(libs.androidx.compose.material.icons.extended)
 
     testImplementation(libs.junit)
+    testImplementation(libs.koin.test)
     testImplementation(libs.org.json)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.core)


### PR DESCRIPTION
## Summary

`libs.koin.test` resolves to `io.insert-koin:koin-test-junit4`, a test-only dependency, but it was declared with `implementation`. That bundled unused JUnit/test code into the release APK and exposed it on the main compile classpath. Nothing in `src/main` references it.

Moved it to `testImplementation`.

## Testing

- `./gradlew test` — BUILD SUCCESSFUL (main + test sources compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)