### PR TITLE
docs: add Obtainium as an installation/update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Download the latest APK from [GitHub Releases](https://github.com/jvsena42/manda
 
 > ⚠️ The APK is **ARM64-only** (`arm64-v8a`). It will not install on x86/x86_64 emulators or devices.
 
-### Obtainium (recommended for auto-updates)
+### Obtainium
 [Obtainium](https://github.com/ImranR98/Obtainium) installs and auto-updates apps directly from their GitHub releases — no Play Store or F-Droid required.
 
 **One tap:** with Obtainium installed, open this link on your device to pre-fill the app:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ If you want zero trust assumptions, a from-genesis IBD (initial block download) 
 ### Releases
 Download the latest APK from [GitHub Releases](https://github.com/jvsena42/mandacaru/releases).
 
+> ⚠️ The APK is **ARM64-only** (`arm64-v8a`). It will not install on x86/x86_64 emulators or devices.
+
+### Obtainium (recommended for auto-updates)
+[Obtainium](https://github.com/ImranR98/Obtainium) installs and auto-updates apps directly from their GitHub releases — no Play Store or F-Droid required.
+
+**One tap:** with Obtainium installed, open this link on your device to pre-fill the app:
+
+```
+obtainium://app/{"id":"com.github.jvsena42.mandacaru","url":"https://github.com/jvsena42/mandacaru","author":"jvsena42","name":"Mandacaru"}
+```
+
+**Manual:** in Obtainium, tap **Add App**, paste `https://github.com/jvsena42/mandacaru` into the *App Source URL* field, then tap **Add**.
+
 ### From Source
 1. Clone the repository:
 ```bash


### PR DESCRIPTION
Adds an **Obtainium** subsection to the README's Installation section, as proposed in #77.

## Changes
- **One-tap deep link** (`obtainium://app/{...}`) pre-filling id, repo URL, author, and name.
- **Manual instructions** — paste the repo URL into Obtainium → Add App.
- **ARM64-only callout** promoted under *Releases* so it applies to every install path.

Docs-only change; no build/lint impact.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)