### PR TITLE
partial fix: copy loaded wallet descriptors to clipboard 

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -310,7 +310,14 @@ private fun ScreenSettings(
                                             .fillMaxWidth()
                                             .padding(vertical = 4.dp)
                                             .clickable {
-                                                clipboardManager.setText(AnnotatedString(descriptor))
+                                                // Extracts standard public keys (xpub, ypub, zpub, tpub, upub, vpub)
+                                                val keyRegex = """([xyzvtu]pub[a-zA-Z0-9]{100,115})""".toRegex()
+                                                val match = keyRegex.find(descriptor)
+                                                
+                                                // If a raw key is found, copy it. Otherwise, fallback to the full string.
+                                                val cleanKey = match?.value ?: descriptor
+                                                
+                                                clipboardManager.setText(AnnotatedString(cleanKey))
                                                 onAction(SettingsAction.OnDescriptorCopied(descriptor))
                                             }
                                             .testTag("button_copy_descriptor"),


### PR DESCRIPTION
Will this resolve https://github.com/jvsena42/mandacaru/issues/113#issuecomment-4725300278 (universality, if not also the zpub/xpub conversion comment after it)? 
Advised by https://share.google/aimode/3dOOCs1kceVeg1NIr

I don't expect this to fix #121, as Electrum app went insane syncing from Mandacaru the existing xpub/p2pkh wallet - which was scanned directly with Electrum app's own QR scanner from Electrum desktop.