### PR TITLE
Add runSuspendCatching and stop swallowing coroutine cancellation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ Lint configuration lives at `app/lint.xml`; detekt configuration lives at `confi
 
 ### Kotlin Conventions
 
-- Prefer `runCatching { ... }` over `try`/`catch` for error handling. When the original code only swallowed a specific exception type, preserve that by re-throwing others in `onFailure` (e.g. `.onFailure { if (it !is IllegalStateException) throw it }`).
+- Prefer `runCatching { ... }` over `try`/`catch` for error handling. When the original code only swallowed a specific exception type, preserve that by re-throwing others in `onFailure` (e.g. `.onFailure { if (it !is IllegalStateException) throw it }`). Reserve `try`/`finally` for guaranteed resource cleanup — that has no `runCatching` equivalent.
+- Inside `suspend` functions or coroutine builders (`launch`/`withContext`/`flow`), use `runSuspendCatching { ... }` (in `com.github.jvsena42.mandacaru.common`) instead of `runCatching` or a generic `try`/`catch` — plain `runCatching` swallows `CancellationException` and breaks structured-concurrency cancellation. `runSuspendCatching` rethrows it.
 - Import types and use the short name rather than fully-qualified names inline (e.g. import `androidx.annotation.OptIn` instead of writing `@androidx.annotation.OptIn(...)`). When the simple name collides with an auto-imported one (`androidx.annotation.OptIn` vs `kotlin.OptIn`), use an import alias (e.g. `import androidx.annotation.OptIn as AndroidXOptIn`).
 
 ### Development Setup

--- a/app/src/main/java/com/github/jvsena42/mandacaru/common/CoroutineExtensions.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/common/CoroutineExtensions.kt
@@ -1,0 +1,16 @@
+package com.github.jvsena42.mandacaru.common
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Like [runCatching], but rethrows [CancellationException] so it never swallows
+ * coroutine cancellation. Use inside suspend functions / coroutine builders.
+ */
+inline fun <T> runSuspendCatching(block: () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+        Result.failure(e)
+    }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaDaemonImpl.kt
@@ -6,6 +6,7 @@ import com.florestad.AssumeValidArg
 import com.florestad.Config
 import com.florestad.Florestad
 import com.github.jvsena42.mandacaru.BuildConfig
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
@@ -29,7 +30,7 @@ class FlorestaDaemonImpl(
 
     override suspend fun start() {
         if (isRunning) return
-        try {
+        runSuspendCatching {
             val pendingSnapshot = preferencesDataSource
                 .getString(PreferenceKeys.PENDING_UTREEXO_SNAPSHOT, "")
                 .takeIf { it.isNotEmpty() }
@@ -79,7 +80,7 @@ class FlorestaDaemonImpl(
             daemon?.start()
             Log.i(TAG, "start: Floresta running (snapshotSource=$snapshotSource)")
             isRunning = true
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        }.onFailure { e ->
             Log.e(TAG, "start error: ", e)
             isRunning = false
         }
@@ -104,7 +105,7 @@ class FlorestaDaemonImpl(
         if (!isRunning || d == null) {
             return@withContext Result.failure(IllegalStateException("Daemon not running"))
         }
-        runCatching { d.dumpUtreexoState() }
+        runSuspendCatching { d.dumpUtreexoState() }
     }
 
     override suspend fun prepareForSnapshotImport(): Result<Unit> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaRpcImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/floresta/FlorestaRpcImpl.kt
@@ -1,6 +1,7 @@
 package com.github.jvsena42.mandacaru.data.floresta
 
 import android.util.Log
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
@@ -18,7 +19,6 @@ import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetTransa
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.ListDescriptorsResponse
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.UptimeResponse
 import com.google.gson.Gson
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -126,18 +126,18 @@ class FlorestaRpcImpl(
 
         val emission = result.fold(
             onSuccess = { json ->
-                try {
-                    val response = when (T::class) {
+                runSuspendCatching {
+                    when (T::class) {
                         JSONObject::class -> json as T
                         else -> gson.fromJson(json.toString(), T::class.java)
                     }
-                    Result.success(response)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                    Log.e(TAG, "${method.method} parse error: ${e.message}")
-                    Result.failure(Exception("Failed to parse response: ${e.message}"))
-                }
+                }.fold(
+                    onSuccess = { Result.success(it) },
+                    onFailure = { e ->
+                        Log.e(TAG, "${method.method} parse error: ${e.message}")
+                        Result.failure(Exception("Failed to parse response: ${e.message}"))
+                    }
+                )
             },
             onFailure = { e ->
                 Log.e(TAG, "${method.method} failure: ${e.message}")

--- a/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateRepositoryImpl.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/data/update/AppUpdateRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.data.update
 
 import android.util.Log
 import com.github.jvsena42.mandacaru.BuildConfig
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.data.AppUpdateRepository
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
@@ -37,7 +38,7 @@ class AppUpdateRepositoryImpl(
         emitCachedStatus()
         if (!force && !isCheckDue()) return@withContext
         _updateStatus.update { it.copy(isChecking = true, checkFailed = false) }
-        runCatching { fetchLatestRelease() }
+        runSuspendCatching { fetchLatestRelease() }
             .onSuccess { release -> applyRelease(release) }
             .onFailure { error ->
                 Log.w(TAG, "refresh: failed to check for updates", error)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/UtreexoSnapshotService.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.domain.floresta
 
 import com.florestad.Network
 import com.florestad.validateUtreexoSnapshotJson
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.presentation.utils.SnapshotCodec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -22,7 +23,7 @@ open class UtreexoSnapshotService(
 
     open suspend fun validate(payload: String, expectedNetwork: Network) =
         withContext(Dispatchers.IO) {
-            runCatching {
+            runSuspendCatching {
                 val json = SnapshotCodec.normalizeToJson(payload)
                 validateUtreexoSnapshotJson(json, expectedNetwork)
             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/DescriptorQrScanner.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/DescriptorQrScanner.kt
@@ -62,9 +62,8 @@ class DefaultDescriptorQrScanner : DescriptorQrScanner {
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
     private fun decodeUr(ur: UR): DescriptorScanState =
-        try {
+        runCatching {
             when (val decoded = ur.decodeFromRegistry()) {
                 is UROutputDescriptor -> completeWith(decoded.source)
                 is URAccountDescriptor ->
@@ -73,13 +72,11 @@ class DefaultDescriptorQrScanner : DescriptorQrScanner {
                 is CryptoOutput, is CryptoAccount -> failWith(LEGACY_UR_ERROR)
                 else -> failWith("This QR code doesn't contain a wallet descriptor")
             }
-        } catch (e: Exception) {
-            failWith(e.message ?: "Failed to decode the wallet descriptor")
-        }
+        }.getOrElse { failWith(it.message ?: "Failed to decode the wallet descriptor") }
 
     private fun ingestBbqr(part: String): DescriptorScanState {
         val joiner = bbqrJoiner ?: BbqrJoiner().also { bbqrJoiner = it }
-        return try {
+        return runCatching {
             when (val result = joiner.addPart(part)) {
                 is BbqrJoiner.Result.InProgress -> {
                     val progress = result.received.toFloat() / result.total
@@ -88,9 +85,7 @@ class DefaultDescriptorQrScanner : DescriptorQrScanner {
                 is BbqrJoiner.Result.Complete ->
                     completeWith(DescriptorUtils.extractDescriptor(String(result.data)))
             }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            failWith(e.message ?: "Failed to decode the BBQr code")
-        }
+        }.getOrElse { failWith(it.message ?: "Failed to decode the BBQr code") }
     }
 
     private fun ingestSingleFrame(text: String): DescriptorScanState =

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScanner.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/scan/QrTransactionScanner.kt
@@ -48,15 +48,13 @@ class DefaultQrTransactionScanner : QrTransactionScanner {
     }
 
     private fun completeWith(ur: UR, transport: ScanTransport): ScanState =
-        try {
+        runCatching {
             ScanState.Complete(ur.toBytes(), transport).also { reset() }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            failWith(e.message ?: "Unsupported QR payload")
-        }
+        }.getOrElse { failWith(it.message ?: "Unsupported QR payload") }
 
     private fun ingestBbqr(part: String): ScanState {
         val joiner = bbqrJoiner ?: BbqrJoiner().also { bbqrJoiner = it }
-        return try {
+        return runCatching {
             when (val result = joiner.addPart(part)) {
                 is BbqrJoiner.Result.InProgress -> {
                     val progress = result.received.toFloat() / result.total
@@ -65,9 +63,7 @@ class DefaultQrTransactionScanner : QrTransactionScanner {
                 is BbqrJoiner.Result.Complete ->
                     ScanState.Complete(result.data, ScanTransport.BBQR).also { reset() }
             }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            failWith(e.message ?: "Failed to decode the BBQr code")
-        }
+        }.getOrElse { failWith(it.message ?: "Failed to decode the BBQr code") }
     }
 
     private fun ingestSingleFrame(text: String): ScanState {

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.graphics.toColorInt
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
@@ -146,14 +147,14 @@ class FlorestaService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
-                try {
+                runCatching {
                     ioScope.launch {
                         Log.d(TAG, "Starting Floresta daemon")
                         florestaDaemon.start()
                     }
                     startNotificationPolling()
                     observeWifiState()
-                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                }.onFailure { e ->
                     Log.e(TAG, "onStartCommand error: ", e)
                 }
             }
@@ -184,7 +185,7 @@ class FlorestaService : Service() {
         notificationPollingJob = ioScope.launch {
             while (true) {
                 delay(NOTIFICATION_POLL_INTERVAL_MS)
-                try {
+                runSuspendCatching {
                     florestaRpc.getBlockchainInfo().collect { result ->
                         result.onSuccess { data ->
                             val peers = florestaRpc.getPeerInfo().firstOrNull()
@@ -224,7 +225,7 @@ class FlorestaService : Service() {
                             )
                         }
                     }
-                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                }.onFailure { e ->
                     Log.d(TAG, "Notification poll failed: ${e.message}")
                 }
             }
@@ -409,7 +410,7 @@ class FlorestaService : Service() {
 
     private suspend fun stopDaemonWithTimeout() {
         Log.d(TAG, "Stopping Floresta daemon")
-        runCatching {
+        runSuspendCatching {
             withTimeoutOrNull(STOP_TIMEOUT_MS) {
                 florestaDaemon.stop()
             }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.florestad.UtreexoImportException
+import com.github.jvsena42.mandacaru.common.runSuspendCatching
 import com.github.jvsena42.mandacaru.data.FlorestaRpc
 import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
@@ -317,7 +318,7 @@ class NodeViewModel(
                 "onConfirmImport: payload len=${payload.length} " +
                     "compact=${SnapshotCodec.isCompact(payload)}",
             )
-            val payloadToPersist = runCatching { SnapshotCodec.normalizeToJson(payload) }
+            val payloadToPersist = runSuspendCatching { SnapshotCodec.normalizeToJson(payload) }
                 .getOrElse { error ->
                     Log.e(TAG, "normalizeToJson failed", error)
                     _uiState.update {

--- a/app/src/test/java/com/github/jvsena42/mandacaru/common/CoroutineExtensionsTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/common/CoroutineExtensionsTest.kt
@@ -1,0 +1,69 @@
+package com.github.jvsena42.mandacaru.common
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CoroutineExtensionsTest {
+
+    @Test
+    fun `returns success with the block result`() {
+        val result = runSuspendCatching { 42 }
+
+        assertTrue(result.isSuccess)
+        assertEquals(42, result.getOrNull())
+    }
+
+    @Test
+    fun `wraps a thrown exception in a failure result`() {
+        val boom = IllegalStateException("boom")
+
+        val result = runSuspendCatching<Int> { throw boom }
+
+        assertTrue(result.isFailure)
+        assertSame(boom, result.exceptionOrNull())
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `rethrows CancellationException instead of wrapping it`() {
+        runSuspendCatching { throw CancellationException("cancelled") }
+    }
+
+    @Test
+    fun `supports suspend calls inside the block`() = runBlocking {
+        suspend fun echo(value: Int): Int {
+            delay(1)
+            return value
+        }
+
+        val result = runSuspendCatching { echo(7) }
+
+        assertEquals(7, result.getOrNull())
+    }
+
+    @Test
+    fun `does not swallow coroutine cancellation so the job actually cancels`() = runBlocking {
+        var completedNormally = false
+        var capturedResult: Result<Unit>? = null
+
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            capturedResult = runSuspendCatching { delay(Long.MAX_VALUE) }
+            completedNormally = true
+        }
+
+        job.cancelAndJoin()
+
+        assertTrue(job.isCancelled)
+        assertFalse("runSuspendCatching swallowed the cancellation", completedNormally)
+        assertNull("cancellation must propagate, not produce a Result", capturedResult)
+    }
+}


### PR DESCRIPTION
## Context

Kotlin's stdlib `runCatching { ... }` catches **every** `Throwable`, including `CancellationException`. Inside a `suspend` function or a coroutine builder (`launch`/`withContext`/`flow`) that silently breaks structured-concurrency cancellation — a cancelled coroutine either keeps running or logs the cancellation as an error. The codebase already had this latent bug in several places, plus one hand-rolled workaround in `FlorestaRpcImpl` (`catch (e: CancellationException) { throw e }`).

## What changed

- **New helper** `common/CoroutineExtensions.kt` — `runSuspendCatching { ... }`: like `runCatching` but rethrows `CancellationException` and wraps everything else in a `Result`. `inline` so it stays usable from `suspend` code.
- **Adopted it in coroutine code paths**: daemon stop-with-timeout (wrapped a `suspend stop()` — the real bug), `FlorestaDaemonImpl.start()`/`dumpUtreexoState()`, the RPC parse block (dropping the manual rethrow + now-unused import), update `refresh()`, snapshot `validate()`, snapshot import in `NodeViewModel`, and the notification poll loop. The synchronous `onStartCommand` try-catch became a plain `runCatching`.
- **Synchronous cleanup**: the QR scanner `try/catch → failWith(...)` blocks became `runCatching { ... }.getOrElse { failWith(...) }` (non-suspend paths, so plain `runCatching` is fine).
- **Left untouched**: `try/finally` resource-cleanup blocks (`BbqrJoiner`, `stop()`, rescan launch), the throw-only translation wrappers in `TransactionDecoder`, the specific-exception catch in `QrCodec`, and generated `florestad.kt`.
- **Docs**: documented the `runSuspendCatching` / try-catch conventions in `CLAUDE.md`.

## Tests

- New `CoroutineExtensionsTest` locks the contract: success wrapping, failure wrapping, `CancellationException` rethrow, suspend-lambda support, and a real `cancelAndJoin` scenario proving cancellation propagates instead of being swallowed.
- The converted scanner error branches are already covered by existing scanner tests (`unrecognized content returns an error`, `garbage frame returns an error`, `legacy crypto-output ur returns a graceful error`).

## Verification

`./gradlew detekt lintDebug assembleDebug test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)