### PR TITLE
feat: add x86_64 (emulator) ABI support

### DIFF
--- a/.claude/commands/update-bindings.md
+++ b/.claude/commands/update-bindings.md
@@ -2,9 +2,9 @@ Update UniFFI bindings for the Mandacaru Android app.
 
 Run the `update-bindings.sh` script from the mandacaru repo root. This script:
 
-1. Cross-compiles `floresta-mandacaru-ffi` for Android ARM64 (aarch64-linux-android)
-2. Generates Kotlin bindings from the UDL interface definition
-3. Copies the native `.so` library to `app/src/main/jniLibs/arm64-v8a/libuniffi_floresta.so`
+1. Cross-compiles `floresta-mandacaru-ffi` for Android `arm64-v8a` (aarch64-linux-android, physical devices) and `x86_64` (x86_64-linux-android, emulators/CI)
+2. Generates Kotlin bindings from the compiled library (uniffi 0.31 `--library` mode; bindings are architecture-independent, generated once)
+3. Copies each native `libflorestad_ffi.so` to its matching `app/src/main/jniLibs/<abi>/` dir (`arm64-v8a`, `x86_64`)
 4. Copies the Kotlin bindings to `app/src/main/java/com/florestad/florestad.kt` (with correct package name)
 
 Execute: `bash ./update-bindings.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Mandacaru is an Android application that runs a lightweight Bitcoin validation n
 ./gradlew dependencyUpdates
 ```
 
-Lint configuration lives at `app/lint.xml`; detekt configuration lives at `config/detekt/detekt.yml`. When a rule fires on generated code or on an intentional project decision (e.g. ARM64-only build), prefer tuning the config over disabling the rule globally.
+Lint configuration lives at `app/lint.xml`; detekt configuration lives at `config/detekt/detekt.yml`. When a rule fires on generated code or on an intentional project decision (e.g. shipping only `arm64-v8a` + `x86_64`, no 32-bit ABIs), prefer tuning the config over disabling the rule globally.
 
 ### Kotlin Conventions
 
@@ -57,7 +57,7 @@ Lint configuration lives at `app/lint.xml`; detekt configuration lives at `confi
 
 ### Development Setup
 - Requires Android 10 (API 29) minimum
-- ARM64 device only (arm64-v8a) - the Rust library is compiled for ARM64 only
+- ARM64 device (arm64-v8a) or x86_64 emulator - the Rust library is cross-compiled for both `arm64-v8a` and `x86_64` (see `update-bindings.sh`); 32-bit ABIs are not built
 - Java 11 language target
 - Android Studio with Compose support recommended
 
@@ -102,7 +102,7 @@ data/                 # Data layer
 
 The app communicates with Rust code via UniFFI-generated bindings:
 
-- **Native Library**: `libuniffi_floresta.so` (ARM64 only)
+- **Native Library**: `libflorestad_ffi.so` (built for `arm64-v8a` and `x86_64`)
 - **Kotlin Bindings**: `com.florestad.florestad.kt` (auto-generated)
 - **Main Classes**:
   - `Florestad`: Rust daemon wrapper with `start()`/`stop()` methods
@@ -231,7 +231,7 @@ When loading wallet descriptors via Settings, use standard Bitcoin descriptor fo
 - RPC tests require running Rust daemon
 
 ### Agentic UI Tests (android-cli journeys)
-- Journey tests live in `journeys/` — natural-language XML steps an AI agent runs via the `android-cli` skill (`android layout`, `adb shell input`) against an installed debug build on an ARM64 device.
+- Journey tests live in `journeys/` — natural-language XML steps an AI agent runs via the `android-cli` skill (`android layout`, `adb shell input`) against an installed debug build on an ARM64 device or x86_64 emulator.
 - `journeys/README.md` is the canonical **testTag contract**: it lists every `testTag` and what it maps to. Keep it in sync when adding/renaming a tag.
 - Compose `testTag`s surface under the `resource-id` key in `android layout` because the root composable (`MainActivity.MandacaruRoot`) sets `testTagsAsResourceId = true`. Prefer targeting these stable ids over localized text or bounds. Two caveats learned from real runs: (1) a `testTag` only surfaces on a node that already emits semantics (interactive controls, text, nav items) — a plain container `Box` with only a `testTag` does not appear, so identify the active screen by the selected nav item's `"state":["selected"]`; (2) dropdowns/dialogs/bottom sheets render in a separate window outside the root subtree, so their `testTag`s do not surface — target items inside them by text.
 - Tags are **inline string literals** at each call site (no shared constants file) to avoid cross-branch merge conflicts. When adding UI an agent must drive, tag it and document it in `journeys/README.md`.

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ If you want zero trust assumptions, a from-genesis IBD (initial block download) 
 
 ### Requirements
 - Android 10 (API 29) or higher
-- ARM64 device (arm64-v8a architecture)
+- ARM64 device (`arm64-v8a`) or x86_64 (`x86_64`, e.g. emulators)
 - Internet connection
 
 ### Releases
 Download the latest APK from [GitHub Releases](https://github.com/jvsena42/mandacaru/releases).
 
-> ⚠️ The APK is **ARM64-only** (`arm64-v8a`). It will not install on x86/x86_64 emulators or devices.
+> ℹ️ The APK ships native libraries for **`arm64-v8a`** (physical devices) and **`x86_64`** (emulators/CI). 32-bit ABIs (`x86`, `armeabi-v7a`) are not supported.
 
 ### Obtainium
 [Obtainium](https://github.com/ImranR98/Obtainium) installs and auto-updates apps directly from their GitHub releases — no Play Store or F-Droid required.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 
         ndk {
             abiFilters += "arm64-v8a"
+            abiFilters += "x86_64"
         }
     }
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -4,8 +4,6 @@
         <ignore path="src/main/java/com/florestad/florestad.kt" />
     </issue>
 
-    <issue id="ChromeOsAbiSupport" severity="ignore" />
-
     <issue id="GradleDependency" severity="ignore" />
     <issue id="AndroidGradlePluginVersion" severity="ignore" />
     <issue id="NewerVersionAvailable" severity="ignore" />

--- a/update-bindings.sh
+++ b/update-bindings.sh
@@ -4,14 +4,17 @@ set -euo pipefail
 # Update UniFFI bindings for Mandacaru Android app
 #
 # This script:
-# 1. Cross-compiles floresta-mandacaru-ffi (with bitcoinkernel) for Android ARM64
+# 1. Cross-compiles floresta-mandacaru-ffi (with bitcoinkernel) for Android
+#    arm64-v8a (aarch64-linux-android) and x86_64 (x86_64-linux-android, emulator)
 # 2. Generates Kotlin bindings from the compiled library (uniffi 0.31 --library)
-# 3. Copies the .so library and Kotlin bindings into the mandacaru app
+# 3. Copies each .so library into the matching jniLibs ABI dir, plus the Kotlin
+#    bindings, into the mandacaru app
 #
 # Prerequisites:
 # - Android NDK 27+ (ANDROID_NDK_ROOT or ~/Android/Sdk/ndk/<version>)
 # - Boost dev headers + CMake config (libboost-all-dev on Debian/Ubuntu), needed
 #   by bitcoinkernel's bundled Bitcoin Core build.
+# - rustup targets aarch64-linux-android and x86_64-linux-android (added below).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FFI_DIR="$(cd "$SCRIPT_DIR/../floresta-mandacaru-ffi" && pwd)"
@@ -22,7 +25,6 @@ NDK_VERSION="${NDK_VERSION:-27.0.12077973}"
 ANDROID_SDK="${ANDROID_HOME:-${HOME}/Android/Sdk}"
 NDK="${ANDROID_NDK_ROOT:-${ANDROID_SDK}/ndk/${NDK_VERSION}}"
 TOOLCHAIN="${NDK}/toolchains/llvm/prebuilt/linux-x86_64"
-TARGET="aarch64-linux-android"
 API_LEVEL="${ANDROID_MIN_SDK:-29}"
 PROFILE="release-smaller"
 PROFILE_DIR="release-smaller"
@@ -49,11 +51,7 @@ if [ -z "$BOOST_CMAKE_DIR" ] || [ ! -f "$BOOST_CMAKE_DIR/BoostConfig.cmake" ]; t
     exit 1
 fi
 
-# Export cross-compilation environment
-export CC_aarch64_linux_android="${TOOLCHAIN}/bin/aarch64-linux-android${API_LEVEL}-clang"
-export CXX_aarch64_linux_android="${TOOLCHAIN}/bin/aarch64-linux-android${API_LEVEL}-clang++"
-export AR_aarch64_linux_android="${TOOLCHAIN}/bin/llvm-ar"
-export CC="aarch64-linux-android${API_LEVEL}-clang"
+# Common cross-compilation environment (arch-independent)
 export ANDROID_NDK_ROOT="$NDK"
 # libbitcoinkernel-sys (android_support) reads ANDROID_NDK_HOME to locate the
 # NDK CMake toolchain file.
@@ -68,31 +66,63 @@ export CMAKE_PREFIX_PATH="$(dirname "$BOOST_CMAKE_DIR"):${CMAKE_PREFIX_PATH:-}"
 # recurse into an existing symlink-to-dir.
 ln -sfn /usr/include/boost "${TOOLCHAIN}/sysroot/usr/include/boost"
 
-# CRITICAL: bitcoinkernel's build needs `-L native=<sysroot libc dir>` so the
-# cdylib dynamically links Bionic libc (otherwise getauxval/init_have_lse_atomics
-# SIGSEGVs at startup). That env var OVERRIDES `.cargo/config.toml` target
-# rustflags, so the 16 KB page-size flag (Google Play / Android 15+) MUST be
-# merged in here too, or it silently regresses.
-NDK_LIB_DIR="${TOOLCHAIN}/sysroot/usr/lib/${TARGET}/${API_LEVEL}"
-export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="aarch64-linux-android${API_LEVEL}-clang"
-export CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS="-L native=${NDK_LIB_DIR} -C link-arg=-Wl,-z,max-page-size=16384"
+rustup target add aarch64-linux-android x86_64-linux-android >/dev/null
 
-echo "==> Building floresta-mandacaru-ffi (bitcoinkernel) for ${TARGET} (API ${API_LEVEL}, ${PROFILE})..."
 cd "$FFI_DIR"
-cargo build --lib --profile "$PROFILE" --target "$TARGET"
 
-SO_PATH="target/${TARGET}/${PROFILE_DIR}/libflorestad_ffi.so"
+# Build the FFI cdylib for one Android target and copy it into the app's jniLibs.
+#   $1 = rust target triple   (e.g. aarch64-linux-android)
+#   $2 = NDK clang prefix      (e.g. aarch64-linux-android — the compiler basename minus API+"-clang")
+#   $3 = jniLibs ABI dir name  (e.g. arm64-v8a)
+#   $4 = extra RUSTFLAGS       (e.g. the 16 KB page-size flag; empty for x86_64)
+build_target() {
+    local target="$1" clang_prefix="$2" abi_dir="$3" extra_rustflags="$4"
+    local cc="${clang_prefix}${API_LEVEL}-clang"
+    local cxx="${clang_prefix}${API_LEVEL}-clang++"
+    # cargo env vars want the target triple upper-cased with '-' -> '_'.
+    local tenv
+    tenv="$(echo "$target" | tr '[:lower:]-' '[:upper:]_')"
 
+    # CRITICAL: bitcoinkernel's build needs `-L native=<sysroot libc dir>` so the
+    # cdylib dynamically links Bionic libc (otherwise getauxval/init_have_lse_atomics
+    # SIGSEGVs at startup on arm64). That env var OVERRIDES `.cargo/config.toml`
+    # target rustflags, so any config-level flag (e.g. the arm64 16 KB page-size
+    # flag for Google Play / Android 15+) MUST be merged in here too via
+    # $extra_rustflags, or it silently regresses.
+    local ndk_lib_dir="${TOOLCHAIN}/sysroot/usr/lib/${target}/${API_LEVEL}"
+
+    export CC_${tenv}="$cc"
+    export CXX_${tenv}="$cxx"
+    export AR_${tenv}="${TOOLCHAIN}/bin/llvm-ar"
+    export CC="$cc"
+    export CARGO_TARGET_${tenv}_LINKER="$cc"
+    export CARGO_TARGET_${tenv}_RUSTFLAGS="-L native=${ndk_lib_dir} ${extra_rustflags}"
+
+    echo "==> Building floresta-mandacaru-ffi (bitcoinkernel) for ${target} (API ${API_LEVEL}, ${PROFILE})..."
+    cargo build --lib --profile "$PROFILE" --target "$target"
+
+    local so_path="target/${target}/${PROFILE_DIR}/libflorestad_ffi.so"
+    local jnilibs_dir="${MANDACARU_DIR}/app/src/main/jniLibs/${abi_dir}"
+    echo "==> Copying native library to mandacaru (${abi_dir})..."
+    mkdir -p "$jnilibs_dir"
+    # cdylib_name = florestad_ffi in uniffi.toml, so the generated bindings load
+    # `libflorestad_ffi.so` directly — no rename.
+    rm -f "${jnilibs_dir}/libuniffi_floresta.so"
+    cp "$so_path" "${jnilibs_dir}/libflorestad_ffi.so"
+}
+
+# arm64-v8a: real devices. Needs the 16 KB page-size flag (Android 15+).
+build_target aarch64-linux-android aarch64-linux-android arm64-v8a \
+    "-C link-arg=-Wl,-z,max-page-size=16384"
+
+# x86_64: emulators / CI. 16 KB flag is arm64-only (x86_64 uses 4 KB pages), so omit it.
+build_target x86_64-linux-android x86_64-linux-android x86_64 ""
+
+# Kotlin bindings are architecture-independent; generate once from either .so.
 echo "==> Generating Kotlin bindings (uniffi 0.31 --library)..."
-cargo run --bin uniffi-bindgen generate --library "$SO_PATH" --language kotlin --out-dir generated/kotlin/ --no-format
-
-echo "==> Copying native library to mandacaru..."
-JNILIBS_DIR="${MANDACARU_DIR}/app/src/main/jniLibs/arm64-v8a"
-mkdir -p "$JNILIBS_DIR"
-# cdylib_name = florestad_ffi in uniffi.toml, so the generated bindings load
-# `libflorestad_ffi.so` directly — no rename.
-rm -f "${JNILIBS_DIR}/libuniffi_floresta.so"
-cp "$SO_PATH" "${JNILIBS_DIR}/libflorestad_ffi.so"
+cargo run --bin uniffi-bindgen generate \
+    --library "target/aarch64-linux-android/${PROFILE_DIR}/libflorestad_ffi.so" \
+    --language kotlin --out-dir generated/kotlin/ --no-format
 
 echo "==> Copying Kotlin bindings to mandacaru..."
 KOTLIN_DIR="${MANDACARU_DIR}/app/src/main/java/com/florestad"
@@ -100,11 +130,18 @@ mkdir -p "$KOTLIN_DIR"
 # package_name = com.florestad in uniffi.toml, so no sed rewrite is needed.
 cp generated/kotlin/com/florestad/floresta.kt "${KOTLIN_DIR}/florestad.kt"
 
-echo "==> Verifying 16 KB alignment + libc linkage..."
+echo "==> Verifying alignment + libc linkage..."
 READELF="$(command -v llvm-readelf || echo "${TOOLCHAIN}/bin/llvm-readelf")"
-"$READELF" -lW "${JNILIBS_DIR}/libflorestad_ffi.so" | awk '/LOAD/{print "    LOAD Align", $NF}'
-"$READELF" -d "${JNILIBS_DIR}/libflorestad_ffi.so" | grep -E "NEEDED.*lib(c|dl|m)\.so" | sed 's/^/    /'
+for abi_dir in arm64-v8a x86_64; do
+    so="${MANDACARU_DIR}/app/src/main/jniLibs/${abi_dir}/libflorestad_ffi.so"
+    echo "  ${abi_dir}:"
+    "$READELF" -lW "$so" | awk '/LOAD/{print "    LOAD Align", $NF}'
+    "$READELF" -d "$so" | grep -E "NEEDED.*lib(c|dl|m)\.so" | sed 's/^/    /'
+done
 
 echo "==> Done!"
-echo "    Library: ${JNILIBS_DIR}/libflorestad_ffi.so ($(du -h "${JNILIBS_DIR}/libflorestad_ffi.so" | cut -f1))"
+for abi_dir in arm64-v8a x86_64; do
+    so="${MANDACARU_DIR}/app/src/main/jniLibs/${abi_dir}/libflorestad_ffi.so"
+    echo "    Library (${abi_dir}): ${so} ($(du -h "$so" | cut -f1))"
+done
 echo "    Bindings: ${KOTLIN_DIR}/florestad.kt"


### PR DESCRIPTION
## Summary

Adds a second native ABI — **`x86_64-linux-android`** — alongside the existing `arm64-v8a`, so Mandacaru installs and runs **natively on x86_64 emulators** (and therefore on hosted x86_64 CI runners, which unblocks the instrumented-test job that was dropped in `4d515af` because no hosted runner can run an arm64 emulator).

Previously the app was arm64-only because the Floresta FFI lib (which builds Bitcoin Core's C++ via `libbitcoinkernel-sys`) was only cross-compiled for arm64. This turned out to be a **tooling** limitation, not a code one: the pinned `jaoleal/rust-bitcoinkernel@android_support` fork already emits `x86_64` objects (`-DANDROID_ABI=x86_64` through the NDK CMake toolchain), so **no FFI-crate change was needed** — only the build script and app packaging.

## Changes
- **`update-bindings.sh`** — parameterized the cross-compile into a per-target function that builds both `aarch64-linux-android` and `x86_64-linux-android`. arm64 keeps the 16 KB `max-page-size` flag (Android 15+); x86_64 omits it (x86_64 uses 4 KB pages). `rustup target add` is run for both; Kotlin bindings (arch-independent) are generated once.
- **`app/build.gradle.kts`** — `abiFilters += "x86_64"` (single universal APK).
- **`app/src/main/jniLibs/x86_64/libflorestad_ffi.so`** — new native lib (~11 MB).
- **`app/lint.xml`** — removed the `ChromeOsAbiSupport` `ignore` (now satisfied; `lintDebug` passes with it un-suppressed).
- **docs** — `README.md`, `CLAUDE.md`, `.claude/commands/update-bindings.md` updated for the two-ABI flow (and fixed the stale `libuniffi_floresta.so` references).

## Verification
- `update-bindings.sh` produces both `jniLibs/{arm64-v8a,x86_64}/libflorestad_ffi.so`; the x86_64 lib is a proper `x86-64` ELF dynamically linked to `libc`/`libdl`/`libm` (readelf: 4 KB LOAD align vs arm64's 16 KB).
- `./gradlew assembleDebug` succeeds; the APK contains `lib/x86_64/` + `lib/arm64-v8a/` (florestad_ffi + all transitive native deps).
- **Runtime on an x86_64 emulator (API 36):** app installs, JNA loads the x86_64 lib (`library_path=.../lib/x86_64`), the Rust node starts, RPC binds on `127.0.0.1:8332`, `getblockchaininfo` returns, peers connect (V2), and headers sync (0 → 22k in ~15s). No `UnsatisfiedLinkError`, no SIGSEGV, no tombstones.
- `./gradlew detekt lintDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)