### PR TITLE
feat: hide peer chips and diagnostics behind advanced features

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -29,6 +29,7 @@ data class NodeUiState(
     val peers: List<PeerUi> = emptyList(),
     val utreexoPeerCount: Int = 0,
     val isPeersExpanded: Boolean = false,
+    val enableAdvancedFeatures: Boolean = false,
     val uptime: String = "",
     val isDiagnosticsExpanded: Boolean = false,
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -60,10 +60,17 @@ class NodeViewModel(
 
     private fun getInLoop() {
         viewModelScope.launch(ioDispatcher) {
+            refreshAdvancedFeatures()
             getInfo()
             delay(10.seconds)
             getInLoop()
         }
+    }
+
+    private suspend fun refreshAdvancedFeatures() {
+        val enabled = preferencesDataSource
+            .getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, false)
+        _uiState.update { it.copy(enableAdvancedFeatures = enabled) }
     }
 
     private fun getInfo() {
@@ -128,6 +135,7 @@ class NodeViewModel(
     }
 
     private suspend fun updateDiagnostics() {
+        if (!_uiState.value.enableAdvancedFeatures) return
         florestaRpc.getUptime().collect { result ->
             result.onSuccess { data ->
                 _uiState.update { it.copy(uptime = formatUptime(data.result)) }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -290,18 +290,18 @@ fun ScreenNode(
     val headerSyncDecimal = uiState.headerSyncDecimal
     val filterSyncDecimal = uiState.filterSyncDecimal
     val isFilterSync = !isHeaderSync
-        && !isStalled
-        && uiState.syncDecimal >= 1f
-        && filterSyncDecimal != null
-        && filterSyncDecimal < 1f
+            && !isStalled
+            && uiState.syncDecimal >= 1f
+            && filterSyncDecimal != null
+            && filterSyncDecimal < 1f
     // Filters reaching the tip doesn't mean the wallet is scanned; while a
     // rescan runs the node is still finding the wallet's transactions, so we
     // surface that instead of claiming "Synced".
     val isWalletScanning = !isHeaderSync
-        && !isStalled
-        && uiState.syncDecimal >= 1f
-        && (filterSyncDecimal == null || filterSyncDecimal >= 1f)
-        && uiState.rescanInProgress
+            && !isStalled
+            && uiState.syncDecimal >= 1f
+            && (filterSyncDecimal == null || filterSyncDecimal >= 1f)
+            && uiState.rescanInProgress
     val syncTitleRes = when {
         isHeaderSync -> R.string.syncing_headers_title
         isStalled -> R.string.sync_stalled_title
@@ -447,11 +447,13 @@ fun ScreenNode(
                         )
                     }
                 }
-                item {
-                    DiagnosticsCard(
-                        uiState = uiState,
-                        onToggle = onToggleDiagnostics,
-                    )
+                if (uiState.enableAdvancedFeatures) {
+                    item {
+                        DiagnosticsCard(
+                            uiState = uiState,
+                            onToggle = onToggleDiagnostics,
+                        )
+                    }
                 }
             }
         }
@@ -700,7 +702,8 @@ private fun PeersCard(
                         uiState.peers.forEachIndexed { index, peer ->
                             PeerItem(
                                 peer = peer,
-                                onDisconnect = { onRequestDisconnect(peer.peer.address) }
+                                onDisconnect = { onRequestDisconnect(peer.peer.address) },
+                                showAdvancedDetails = uiState.enableAdvancedFeatures,
                             )
                             if (index < uiState.peers.lastIndex) {
                                 HorizontalDivider(
@@ -861,11 +864,13 @@ private fun SyncProgressBar(
             color = MaterialTheme.colorScheme.error,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
+
         rawDecimal == null -> LinearProgressIndicator(
             modifier = barModifier,
             color = MaterialTheme.colorScheme.primary,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
+
         else -> LinearProgressIndicator(
             progress = { animatedDecimal },
             modifier = barModifier,
@@ -881,7 +886,7 @@ private fun SyncProgressTitleRow(titleRes: Int, percentageText: String?) {
         targetState = titleRes,
         transitionSpec = {
             fadeIn(animationSpec = tween(300)) togetherWith
-                fadeOut(animationSpec = tween(300))
+                    fadeOut(animationSpec = tween(300))
         },
         label = "syncTitle",
     ) { currentTitleRes ->
@@ -948,7 +953,8 @@ private fun SyncProgressCard(
         label = "syncProgress",
     )
     val percentageText = inputs.percentageText()
-    val steps = computeSyncStepStates(isHeaderSync, syncDecimal, filterSyncDecimal, rescanInProgress)
+    val steps =
+        computeSyncStepStates(isHeaderSync, syncDecimal, filterSyncDecimal, rescanInProgress)
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -965,9 +971,9 @@ private fun SyncProgressCard(
             AnimatedVisibility(
                 visible = !isStalled && !steps.allDone,
                 enter = fadeIn(animationSpec = tween(300)) +
-                    expandVertically(animationSpec = tween(300)),
+                        expandVertically(animationSpec = tween(300)),
                 exit = fadeOut(animationSpec = tween(300)) +
-                    shrinkVertically(animationSpec = tween(300)),
+                        shrinkVertically(animationSpec = tween(300)),
             ) {
                 Column {
                     SyncStepper(
@@ -1230,7 +1236,7 @@ internal fun UtreexoWarningCard() {
             )
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                stringResource(R.string.utreexo_warning_title),
+                    stringResource(R.string.utreexo_warning_title),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onErrorContainer
@@ -1248,7 +1254,8 @@ internal fun UtreexoWarningCard() {
 @Composable
 internal fun PeerItem(
     peer: PeerUi,
-    onDisconnect: () -> Unit = {}
+    onDisconnect: () -> Unit = {},
+    showAdvancedDetails: Boolean = false,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -1307,12 +1314,14 @@ internal fun PeerItem(
         }
 
         Spacer(modifier = Modifier.height(2.dp))
+        if (showAdvancedDetails) {
 
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            PeerChip(peer.peer.state)
-            PeerChip(peer.peer.kind)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                PeerChip(peer.peer.state)
+                PeerChip(peer.peer.kind)
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNodeTablet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNodeTablet.kt
@@ -133,7 +133,9 @@ internal fun TabletNodeDashboard(
                     onPingClick = onPingClick,
                     onRequestDisconnect = onRequestDisconnect,
                 )
-                TabletDiagnosticsCard(uiState = uiState)
+                if (uiState.enableAdvancedFeatures) {
+                    TabletDiagnosticsCard(uiState = uiState)
+                }
             }
         }
     }
@@ -448,6 +450,7 @@ private fun TabletPeersCard(
                         PeerItem(
                             peer = peer,
                             onDisconnect = { onRequestDisconnect(peer.peer.address) },
+                            showAdvancedDetails = uiState.enableAdvancedFeatures,
                         )
                         if (index < uiState.peers.lastIndex) {
                             HorizontalDivider(


### PR DESCRIPTION
## Summary

Gates two node-internals UI surfaces on the existing **advanced features** setting (`ENABLE_ADVANCED_FEATURES`), so the Node screen stays focused for users who never act on them.

- **Peer state/kind chips** — `PeerItem` takes a new `showAdvancedDetails` param (defaults to `false`) that gates the `PeerChip` row. The country flag, address, user agent, service flags, and disconnect button remain visible for everyone.
- **Diagnostics card** — gated at both call sites (`ScreenNode` phone grid and `ScreenNodeTablet`), so the card drops out of the layout entirely rather than rendering an empty expandable header. Uptime is its only row, so gating the whole card beats gating its contents.
- **`getUptime` poll** — `NodeViewModel.updateDiagnostics()` returns early when the flag is off; it was firing every ten seconds for a card nobody could see. The peer and blockchain polls are untouched.

No new preference or toggle — this reuses the setting that already gates the advanced blocks in Settings.

## Notes for the reviewer

- The flag is read at the top of the existing 10-second poll loop rather than reactively, since `PreferencesDataSource` only exposes suspend getters. Toggling the setting therefore takes up to 10s to reflect on an already-open Node screen. A `Flow`-returning method on that interface would fix it if the delay is worth the plumbing.
- This branch also carries some IDE reformatting in `ScreenNode.kt` (continuation indents, blank lines around `when` branches) that is unrelated to the behaviour change.
- Nothing in `journeys/` references these surfaces, so the testTag contract needed no update.

## Testing

`./gradlew compileDebugKotlin detekt lintDebug testDebugUnitTest` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)