### PR TITLE
feat: share descriptor as Electrum (SLIP-132) key

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
@@ -1,5 +1,11 @@
 package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -103,23 +109,33 @@ private fun DescriptorShareSheetContent(
             }
         }
 
-        when (selectedTab) {
-            0 -> ShareTabContent(
-                value = descriptor,
-                description = stringResource(R.string.share_descriptor_wallets),
-                copyTestTag = "button_copy_descriptor",
-                onCopy = { onCopy(descriptor, true) },
-            )
-
-            else -> if (electrumKey != null) {
-                ShareTabContent(
-                    value = electrumKey,
-                    description = stringResource(R.string.share_electrum_wallets),
-                    copyTestTag = "button_copy_extended_key",
-                    onCopy = { onCopy(electrumKey, false) },
+        AnimatedContent(
+            targetState = selectedTab,
+            transitionSpec = {
+                val direction = if (targetState > initialState) 1 else -1
+                (slideInHorizontally { width -> direction * width } + fadeIn()) togetherWith
+                    (slideOutHorizontally { width -> -direction * width } + fadeOut())
+            },
+            label = "shareTabContent",
+        ) { tab ->
+            when (tab) {
+                0 -> ShareTabContent(
+                    value = descriptor,
+                    description = stringResource(R.string.share_descriptor_wallets),
+                    copyTestTag = "button_copy_descriptor",
+                    onCopy = { onCopy(descriptor, true) },
                 )
-            } else {
-                UnavailableNotice()
+
+                else -> if (electrumKey != null) {
+                    ShareTabContent(
+                        value = electrumKey,
+                        description = stringResource(R.string.share_electrum_wallets),
+                        copyTestTag = "button_copy_extended_key",
+                        onCopy = { onCopy(electrumKey, false) },
+                    )
+                } else {
+                    UnavailableNotice()
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
@@ -74,7 +74,7 @@ private fun DescriptorShareSheetContent(
     var selectedTab by remember { mutableIntStateOf(0) }
 
     Column(
-        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+        modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val segmentColors = SegmentedButtonDefaults.colors(
@@ -191,6 +191,8 @@ private fun ShareTabContent(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
             )
         }
+
+        Spacer(modifier = Modifier.weight(1f, fill = false))
 
         OutlinedButton(
             onClick = onCopy,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
@@ -1,0 +1,199 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.settings
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
+import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
+import com.github.jvsena42.mandacaru.presentation.utils.encodeQr
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DescriptorShareSheet(
+    descriptor: String,
+    onCopy: (value: String, isDescriptor: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        DescriptorShareSheetContent(descriptor = descriptor, onCopy = onCopy)
+    }
+}
+
+@Composable
+private fun DescriptorShareSheetContent(
+    descriptor: String,
+    onCopy: (value: String, isDescriptor: Boolean) -> Unit,
+) {
+    val electrumKey = remember(descriptor) { DescriptorUtils.electrumKeyFor(descriptor) }
+    var selectedTab by remember { mutableIntStateOf(0) }
+
+    Column(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+        PrimaryTabRow(selectedTabIndex = selectedTab) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { selectedTab = 0 },
+                text = { Text(stringResource(R.string.tab_descriptor)) },
+                modifier = Modifier.testTag("tab_descriptor"),
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { selectedTab = 1 },
+                text = { Text(stringResource(R.string.tab_extended_key)) },
+                modifier = Modifier.testTag("tab_extended_key"),
+            )
+        }
+
+        when (selectedTab) {
+            0 -> ShareTabContent(
+                value = descriptor,
+                description = stringResource(R.string.share_descriptor_wallets),
+                copyTestTag = "button_copy_descriptor",
+                onCopy = { onCopy(descriptor, true) },
+            )
+
+            else -> if (electrumKey != null) {
+                ShareTabContent(
+                    value = electrumKey,
+                    description = stringResource(R.string.share_electrum_wallets),
+                    copyTestTag = "button_copy_extended_key",
+                    onCopy = { onCopy(electrumKey, false) },
+                )
+            } else {
+                UnavailableNotice()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShareTabContent(
+    value: String,
+    description: String,
+    copyTestTag: String,
+    onCopy: () -> Unit,
+) {
+    val qr = remember(value) { encodeQr(value, size = QR_SIZE_PX) }
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (qr != null) {
+            Box(
+                modifier = Modifier
+                    .size(QR_DISPLAY_DP.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.White),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    bitmap = qr,
+                    contentDescription = null,
+                    modifier = Modifier.size((QR_DISPLAY_DP - 16).dp),
+                )
+            }
+        } else {
+            Text(
+                stringResource(R.string.utreexo_error_too_large_for_qr),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        SelectionContainer {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+            )
+        }
+
+        FilledTonalButton(
+            onClick = onCopy,
+            modifier = Modifier.fillMaxWidth().testTag(copyTestTag),
+        ) {
+            Icon(Icons.Outlined.ContentCopy, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.utreexo_copy))
+        }
+
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun UnavailableNotice() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.share_electrum_unavailable),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+private const val QR_SIZE_PX = 768
+private const val QR_DISPLAY_DP = 280
+
+private const val SAMPLE_DESCRIPTOR =
+    "wpkh([a5b13c0e/84h/0h/0h]xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5g" +
+        "fAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)"
+
+@PreviewLightDark
+@Composable
+private fun DescriptorShareSheetPreview() {
+    MandacaruTheme {
+        Surface {
+            DescriptorShareSheetContent(descriptor = SAMPLE_DESCRIPTOR, onCopy = { _, _ -> })
+        }
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -35,13 +37,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -50,94 +55,112 @@ import com.github.jvsena42.mandacaru.R
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
 import com.github.jvsena42.mandacaru.presentation.utils.encodeQr
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DescriptorShareSheet(
     descriptor: String,
-    onCopy: (value: String, isDescriptor: Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        DescriptorShareSheetContent(descriptor = descriptor, onCopy = onCopy)
+        DescriptorShareSheetContent(descriptor = descriptor)
     }
 }
 
 @Composable
-private fun DescriptorShareSheetContent(
-    descriptor: String,
-    onCopy: (value: String, isDescriptor: Boolean) -> Unit,
-) {
+private fun DescriptorShareSheetContent(descriptor: String) {
     val electrumKey = remember(descriptor) { DescriptorUtils.electrumKeyFor(descriptor) }
     var selectedTab by remember { mutableIntStateOf(0) }
 
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        val segmentColors = SegmentedButtonDefaults.colors(
-            activeContainerColor = MaterialTheme.colorScheme.primary,
-            activeContentColor = MaterialTheme.colorScheme.onPrimary,
-            activeBorderColor = MaterialTheme.colorScheme.primary,
-        )
-        SingleChoiceSegmentedButtonRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-        ) {
-            SegmentedButton(
-                selected = selectedTab == 0,
-                onClick = { selectedTab = 0 },
-                shape = SegmentedButtonDefaults.itemShape(index = 0, count = SEGMENT_COUNT),
-                colors = segmentColors,
-                icon = {},
-                modifier = Modifier.testTag("tab_descriptor"),
-            ) {
-                Text(stringResource(R.string.tab_descriptor))
-            }
-            SegmentedButton(
-                selected = selectedTab == 1,
-                onClick = { selectedTab = 1 },
-                shape = SegmentedButtonDefaults.itemShape(index = 1, count = SEGMENT_COUNT),
-                colors = segmentColors,
-                icon = {},
-                modifier = Modifier.testTag("tab_extended_key"),
-            ) {
-                Text(stringResource(R.string.tab_extended_key))
-            }
+    val clipboard = LocalClipboardManager.current
+    val descriptorCopied = stringResource(R.string.descriptor_copied)
+    val keyCopied = stringResource(R.string.extended_key_copied)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val onCopy: (value: String, isDescriptor: Boolean) -> Unit = { value, isDescriptor ->
+        clipboard.setText(AnnotatedString(value))
+        val message = if (isDescriptor) descriptorCopied else keyCopied
+        scope.launch {
+            snackbarHostState.currentSnackbarData?.dismiss()
+            snackbarHostState.showSnackbar(message)
         }
+    }
 
-        AnimatedContent(
-            targetState = selectedTab,
-            transitionSpec = {
-                val direction = if (targetState > initialState) 1 else -1
-                (slideInHorizontally { width -> direction * width } + fadeIn()) togetherWith
-                    (slideOutHorizontally { width -> -direction * width } + fadeOut())
-            },
-            label = "shareTabContent",
-        ) { tab ->
-            when (tab) {
-                0 -> ShareTabContent(
-                    value = descriptor,
-                    description = stringResource(R.string.share_descriptor_wallets),
-                    copyTestTag = "button_copy_descriptor",
-                    onCopy = { onCopy(descriptor, true) },
-                )
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            val segmentColors = SegmentedButtonDefaults.colors(
+                activeContainerColor = MaterialTheme.colorScheme.primary,
+                activeContentColor = MaterialTheme.colorScheme.onPrimary,
+                activeBorderColor = MaterialTheme.colorScheme.primary,
+            )
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                SegmentedButton(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = SEGMENT_COUNT),
+                    colors = segmentColors,
+                    icon = {},
+                    modifier = Modifier.testTag("tab_descriptor"),
+                ) {
+                    Text(stringResource(R.string.tab_descriptor))
+                }
+                SegmentedButton(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = SEGMENT_COUNT),
+                    colors = segmentColors,
+                    icon = {},
+                    modifier = Modifier.testTag("tab_extended_key"),
+                ) {
+                    Text(stringResource(R.string.tab_extended_key))
+                }
+            }
 
-                else -> if (electrumKey != null) {
-                    ShareTabContent(
-                        value = electrumKey,
-                        description = stringResource(R.string.share_electrum_wallets),
-                        copyTestTag = "button_copy_extended_key",
-                        onCopy = { onCopy(electrumKey, false) },
+            AnimatedContent(
+                targetState = selectedTab,
+                transitionSpec = {
+                    val direction = if (targetState > initialState) 1 else -1
+                    (slideInHorizontally { width -> direction * width } + fadeIn()) togetherWith
+                        (slideOutHorizontally { width -> -direction * width } + fadeOut())
+                },
+                label = "shareTabContent",
+            ) { tab ->
+                when (tab) {
+                    0 -> ShareTabContent(
+                        value = descriptor,
+                        description = stringResource(R.string.share_descriptor_wallets),
+                        copyTestTag = "button_copy_descriptor",
+                        onCopy = { onCopy(descriptor, true) },
                     )
-                } else {
-                    UnavailableNotice()
+
+                    else -> if (electrumKey != null) {
+                        ShareTabContent(
+                            value = electrumKey,
+                            description = stringResource(R.string.share_electrum_wallets),
+                            copyTestTag = "button_copy_extended_key",
+                            onCopy = { onCopy(electrumKey, false) },
+                        )
+                    } else {
+                        UnavailableNotice()
+                    }
                 }
             }
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
     }
 }
 
@@ -233,7 +256,7 @@ private const val SAMPLE_DESCRIPTOR =
 private fun DescriptorShareSheetPreview() {
     MandacaruTheme {
         Surface {
-            DescriptorShareSheetContent(descriptor = SAMPLE_DESCRIPTOR, onCopy = { _, _ -> })
+            DescriptorShareSheetContent(descriptor = SAMPLE_DESCRIPTOR)
         }
     }
 }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/DescriptorShareSheet.kt
@@ -15,13 +15,14 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -66,20 +67,40 @@ private fun DescriptorShareSheetContent(
     val electrumKey = remember(descriptor) { DescriptorUtils.electrumKeyFor(descriptor) }
     var selectedTab by remember { mutableIntStateOf(0) }
 
-    Column(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
-        PrimaryTabRow(selectedTabIndex = selectedTab) {
-            Tab(
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val segmentColors = SegmentedButtonDefaults.colors(
+            activeContainerColor = MaterialTheme.colorScheme.primary,
+            activeContentColor = MaterialTheme.colorScheme.onPrimary,
+            activeBorderColor = MaterialTheme.colorScheme.primary,
+        )
+        SingleChoiceSegmentedButtonRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            SegmentedButton(
                 selected = selectedTab == 0,
                 onClick = { selectedTab = 0 },
-                text = { Text(stringResource(R.string.tab_descriptor)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = SEGMENT_COUNT),
+                colors = segmentColors,
+                icon = {},
                 modifier = Modifier.testTag("tab_descriptor"),
-            )
-            Tab(
+            ) {
+                Text(stringResource(R.string.tab_descriptor))
+            }
+            SegmentedButton(
                 selected = selectedTab == 1,
                 onClick = { selectedTab = 1 },
-                text = { Text(stringResource(R.string.tab_extended_key)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = SEGMENT_COUNT),
+                colors = segmentColors,
+                icon = {},
                 modifier = Modifier.testTag("tab_extended_key"),
-            )
+            ) {
+                Text(stringResource(R.string.tab_extended_key))
+            }
         }
 
         when (selectedTab) {
@@ -117,6 +138,13 @@ private fun ShareTabContent(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        Text(
+            text = description,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+
         if (qr != null) {
             Box(
                 modifier = Modifier
@@ -148,7 +176,7 @@ private fun ShareTabContent(
             )
         }
 
-        FilledTonalButton(
+        OutlinedButton(
             onClick = onCopy,
             modifier = Modifier.fillMaxWidth().testTag(copyTestTag),
         ) {
@@ -156,13 +184,6 @@ private fun ShareTabContent(
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.utreexo_copy))
         }
-
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
     }
 }
 
@@ -181,6 +202,7 @@ private fun UnavailableNotice() {
     }
 }
 
+private const val SEGMENT_COUNT = 2
 private const val QR_SIZE_PX = 768
 private const val QR_DISPLAY_DP = 280
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -302,7 +302,6 @@ private fun ScreenSettings(
                         onToggle = { onAction(SettingsAction.ToggleDescriptorsExpanded) },
                         modifier = Modifier.animateItem(),
                     ) {
-                        val clipboardManager = LocalClipboardManager.current
                         Column(modifier = Modifier.fillMaxWidth()) {
                             if (uiState.descriptors.isNotEmpty()) {
                                 uiState.descriptors.forEach { descriptor ->
@@ -311,10 +310,9 @@ private fun ScreenSettings(
                                             .fillMaxWidth()
                                             .padding(vertical = 4.dp)
                                             .clickable {
-                                                clipboardManager.setText(AnnotatedString(descriptor))
-                                                onAction(SettingsAction.OnDescriptorCopied(descriptor))
+                                                onAction(SettingsAction.OnClickShareDescriptor(descriptor))
                                             }
-                                            .testTag("button_copy_descriptor"),
+                                            .testTag("button_share_descriptor"),
                                         shape = RoundedCornerShape(8.dp),
                                         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
                                     ) {
@@ -334,8 +332,8 @@ private fun ScreenSettings(
                                                 modifier = Modifier.weight(1f)
                                             )
                                             Icon(
-                                                Icons.Outlined.ContentCopy,
-                                                contentDescription = "Copy",
+                                                Icons.Outlined.Share,
+                                                contentDescription = stringResource(R.string.share_descriptor),
                                                 modifier = Modifier
                                                     .padding(start = 12.dp)
                                                     .size(20.dp),
@@ -1017,6 +1015,18 @@ private fun ScreenSettings(
                 pending = pending,
                 onConfirm = { currentOnAction(SettingsAction.OnConfirmScannedDescriptor) },
                 onDismiss = { currentOnAction(SettingsAction.OnDismissScannedDescriptor) },
+            )
+        }
+
+        uiState.descriptorToShare?.let { descriptor ->
+            val clipboardManager = LocalClipboardManager.current
+            DescriptorShareSheet(
+                descriptor = descriptor,
+                onCopy = { value, isDescriptor ->
+                    clipboardManager.setText(AnnotatedString(value))
+                    currentOnAction(SettingsAction.OnDescriptorShareCopied(isDescriptor))
+                },
+                onDismiss = { currentOnAction(SettingsAction.OnDismissDescriptorShareSheet) },
             )
         }
     }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -1019,13 +1019,8 @@ private fun ScreenSettings(
         }
 
         uiState.descriptorToShare?.let { descriptor ->
-            val clipboardManager = LocalClipboardManager.current
             DescriptorShareSheet(
                 descriptor = descriptor,
-                onCopy = { value, isDescriptor ->
-                    clipboardManager.setText(AnnotatedString(value))
-                    currentOnAction(SettingsAction.OnDescriptorShareCopied(isDescriptor))
-                },
                 onDismiss = { currentOnAction(SettingsAction.OnDismissDescriptorShareSheet) },
             )
         }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -14,7 +14,6 @@ sealed interface SettingsAction {
     object OnDismissScannedDescriptor: SettingsAction
     data class OnClickShareDescriptor(val descriptor: String): SettingsAction
     object OnDismissDescriptorShareSheet: SettingsAction
-    data class OnDescriptorShareCopied(val isDescriptor: Boolean): SettingsAction
     object OnClickConnectNode: SettingsAction
     object OnClickRescan: SettingsAction
     object ClearSnackBarMessage: SettingsAction

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsAction.kt
@@ -12,7 +12,9 @@ sealed interface SettingsAction {
     data class OnDescriptorQrFrameScanned(val raw: String): SettingsAction
     object OnConfirmScannedDescriptor: SettingsAction
     object OnDismissScannedDescriptor: SettingsAction
-    data class OnDescriptorCopied(val descriptor: String): SettingsAction
+    data class OnClickShareDescriptor(val descriptor: String): SettingsAction
+    object OnDismissDescriptorShareSheet: SettingsAction
+    data class OnDescriptorShareCopied(val isDescriptor: Boolean): SettingsAction
     object OnClickConnectNode: SettingsAction
     object OnClickRescan: SettingsAction
     object ClearSnackBarMessage: SettingsAction

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -19,6 +19,7 @@ data class SettingsUiState(
     val descriptorScanProgress: Float = 0f,
     val descriptorScanError: String = "",
     val pendingScannedDescriptor: PendingDescriptor? = null,
+    val descriptorToShare: String? = null,
     val electrumAddress: String = "",
     val nodeAddress: String = "",
     val nodeAddressError: Int? = null,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -144,8 +144,22 @@ class SettingsViewModel(
                 it.copy(pendingScannedDescriptor = null)
             }
 
-            is SettingsAction.OnDescriptorCopied -> _uiState.update {
-                it.copy(snackBarMessage = "Descriptor copied to clipboard")
+            is SettingsAction.OnClickShareDescriptor -> _uiState.update {
+                it.copy(descriptorToShare = action.descriptor)
+            }
+
+            SettingsAction.OnDismissDescriptorShareSheet -> _uiState.update {
+                it.copy(descriptorToShare = null)
+            }
+
+            is SettingsAction.OnDescriptorShareCopied -> _uiState.update {
+                it.copy(
+                    snackBarMessage = if (action.isDescriptor) {
+                        "Descriptor copied to clipboard"
+                    } else {
+                        "Extended public key copied to clipboard"
+                    },
+                )
             }
 
             SettingsAction.OnClickRescan -> rescan()

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -152,16 +152,6 @@ class SettingsViewModel(
                 it.copy(descriptorToShare = null)
             }
 
-            is SettingsAction.OnDescriptorShareCopied -> _uiState.update {
-                it.copy(
-                    snackBarMessage = if (action.isDescriptor) {
-                        "Descriptor copied to clipboard"
-                    } else {
-                        "Extended public key copied to clipboard"
-                    },
-                )
-            }
-
             SettingsAction.OnClickRescan -> rescan()
             SettingsAction.ClearSnackBarMessage -> _uiState.update { it.copy(snackBarMessage = "") }
             SettingsAction.OnClickConnectNode -> connectNode()

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/DescriptorUtils.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/utils/DescriptorUtils.kt
@@ -21,6 +21,9 @@ object DescriptorUtils {
     )
     private val JSON_DESCRIPTOR_KEYS = listOf("descriptor", "desc", "output_descriptor")
 
+    // Base58 run of an extended key (xpub/tpub and SLIP-132 variants), origin/derivation excluded.
+    private val EXTENDED_KEY_REGEX = Regex("""[xyztuvYZUV]pub[1-9A-HJ-NP-Za-km-z]{100,115}""")
+
     private val POLICY_REGEX = Regex("""(\d+)\s+of\s+\d+""", RegexOption.IGNORE_CASE)
     private val POLICY_LINE_REGEX = Regex("""(?im)^\s*Policy\s*:""")
     private val FORMAT_LINE_REGEX = Regex("""(?im)^\s*Format\s*:""")
@@ -66,6 +69,32 @@ object DescriptorUtils {
             input.startsWith("xpub") || input.startsWith("tpub") -> "pkh($keyWithPath)"
             else -> input
         }
+    }
+
+    /**
+     * The SLIP-132 extended public key Electrum expects for this descriptor, matching its script
+     * type (`wpkh`→`zpub`/`vpub`, `sh(wpkh)`→`ypub`/`upub`, `pkh`→`xpub`/`tpub`). Electrum has no
+     * descriptor support and infers the wallet type from the key's version-byte prefix, so a bare
+     * standard `xpub` would be read as legacy. Returns null when there is no valid single-key
+     * export: multisig, taproot, or no extractable extended key.
+     */
+    @Suppress("ReturnCount")
+    fun electrumKeyFor(descriptor: String): String? {
+        val trimmed = descriptor.trim()
+        if (trimmed.startsWith("tr(") || trimmed.contains("multi(")) return null
+
+        val rawKey = EXTENDED_KEY_REGEX.find(trimmed)?.value ?: return null
+        val standardKey = convertSlip132ToStandard(rawKey)
+        val testnet = standardKey.startsWith("tpub")
+        if (!testnet && !standardKey.startsWith("xpub")) return null
+
+        val target = when {
+            trimmed.startsWith("wpkh(") -> if (testnet) VERSION_MAGIC_VPUB else VERSION_MAGIC_ZPUB
+            trimmed.startsWith("sh(wpkh(") -> if (testnet) VERSION_MAGIC_UPUB else VERSION_MAGIC_YPUB
+            trimmed.startsWith("pkh(") -> if (testnet) VERSION_MAGIC_TPUB else VERSION_MAGIC_XPUB
+            else -> return null
+        }
+        return reencodeVersion(standardKey, target)
     }
 
     fun isPrivateKey(input: String): Boolean {
@@ -221,6 +250,14 @@ object DescriptorUtils {
         val standardPrefix = SLIP132_TO_STANDARD[prefix] ?: return key
 
         standardPrefix.copyInto(decoded, 0)
+        return base58CheckEncode(decoded)
+    }
+
+    /** Re-encodes an extended key with new version bytes (the inverse of the SLIP-132 mapping). */
+    private fun reencodeVersion(key: String, target: ByteArray): String? {
+        val decoded = base58CheckDecode(key) ?: return null
+        if (decoded.size < VERSION_PREFIX_LENGTH) return null
+        target.copyInto(decoded, 0)
         return base58CheckEncode(decoded)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,12 @@
     <string name="validated_blocks">Validated Blocks</string>
     <string name="descriptors">Descriptors</string>
     <string name="no_descriptors_loaded">No descriptors loaded yet</string>
+    <string name="share_descriptor">Share</string>
+    <string name="tab_descriptor">Descriptor</string>
+    <string name="tab_extended_key">Extended key</string>
+    <string name="share_descriptor_wallets">Modern wallets like Sparrow, BlueWallet, Specter</string>
+    <string name="share_electrum_wallets">Electrum and older wallets</string>
+    <string name="share_electrum_unavailable">Not available for this wallet type — Electrum can\'t import multisig or taproot as a single key.</string>
     <string name="diagnostics">Diagnostics</string>
     <string name="blockchain">Blockchain</string>
     <string name="chain_status">Chain Status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="share_descriptor_wallets">Modern wallets like Sparrow, BlueWallet, Specter</string>
     <string name="share_electrum_wallets">Electrum and older wallets</string>
     <string name="share_electrum_unavailable">Not available for this wallet type — Electrum can\'t import multisig or taproot as a single key.</string>
+    <string name="descriptor_copied">Descriptor copied to clipboard</string>
+    <string name="extended_key_copied">Extended public key copied to clipboard</string>
     <string name="diagnostics">Diagnostics</string>
     <string name="blockchain">Blockchain</string>
     <string name="chain_status">Chain Status</string>

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
@@ -66,19 +66,35 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `copying a descriptor surfaces the copied confirmation`() {
+    fun `sharing a descriptor opens the share sheet and dismissing closes it`() {
         val vm = buildViewModel()
 
-        vm.onAction(SettingsAction.OnDescriptorCopied(DESCRIPTOR))
+        vm.onAction(SettingsAction.OnClickShareDescriptor(DESCRIPTOR))
         dispatcher.scheduler.runCurrent()
+        assertEquals(DESCRIPTOR, vm.uiState.value.descriptorToShare)
 
+        vm.onAction(SettingsAction.OnDismissDescriptorShareSheet)
+        dispatcher.scheduler.runCurrent()
+        assertEquals(null, vm.uiState.value.descriptorToShare)
+    }
+
+    @Test
+    fun `copying surfaces the confirmation for descriptor and extended key`() {
+        val vm = buildViewModel()
+
+        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = true))
+        dispatcher.scheduler.runCurrent()
         assertEquals("Descriptor copied to clipboard", vm.uiState.value.snackBarMessage)
+
+        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = false))
+        dispatcher.scheduler.runCurrent()
+        assertEquals("Extended public key copied to clipboard", vm.uiState.value.snackBarMessage)
     }
 
     @Test
     fun `clearing the snackbar resets the message`() {
         val vm = buildViewModel()
-        vm.onAction(SettingsAction.OnDescriptorCopied(DESCRIPTOR))
+        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = true))
         dispatcher.scheduler.runCurrent()
 
         vm.onAction(SettingsAction.ClearSnackBarMessage)

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModelTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -79,23 +80,13 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `copying surfaces the confirmation for descriptor and extended key`() {
-        val vm = buildViewModel()
-
-        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = true))
-        dispatcher.scheduler.runCurrent()
-        assertEquals("Descriptor copied to clipboard", vm.uiState.value.snackBarMessage)
-
-        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = false))
-        dispatcher.scheduler.runCurrent()
-        assertEquals("Extended public key copied to clipboard", vm.uiState.value.snackBarMessage)
-    }
-
-    @Test
     fun `clearing the snackbar resets the message`() {
         val vm = buildViewModel()
-        vm.onAction(SettingsAction.OnDescriptorShareCopied(isDescriptor = true))
+        // Seed a message synchronously via the private-key rejection path.
+        vm.onAction(SettingsAction.OnDescriptorChanged("xprv9s21ZrQH143K3GJpoapnV8SFfuZcECeGTqTKP9HYSnmgYfq6"))
+        vm.onAction(SettingsAction.OnClickUpdateDescriptor)
         dispatcher.scheduler.runCurrent()
+        assertTrue(vm.uiState.value.snackBarMessage.isNotEmpty())
 
         vm.onAction(SettingsAction.ClearSnackBarMessage)
         dispatcher.scheduler.runCurrent()

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/DescriptorUtilsTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/utils/DescriptorUtilsTest.kt
@@ -216,6 +216,49 @@ class DescriptorUtilsTest {
         assertEquals(null, DescriptorUtils.extractDescriptor(""))
     }
 
+    // --- electrumKeyFor (SLIP-132 export; ground truth = official BIP test vectors) ---
+
+    @Test
+    fun `electrumKeyFor produces the BIP84 zpub for a native segwit descriptor`() {
+        val xpub = DescriptorUtils.convertSlip132ToStandard(realZpub)
+        val descriptor = "wpkh([00000000/84h/0h/0h]$xpub/<0;1>/*)"
+        assertEquals(realZpub, DescriptorUtils.electrumKeyFor(descriptor))
+    }
+
+    @Test
+    fun `electrumKeyFor produces the BIP49 upub for a testnet nested segwit descriptor`() {
+        val tpub = DescriptorUtils.convertSlip132ToStandard(BIP49_TESTNET_UPUB)
+        val descriptor = "sh(wpkh($tpub/<0;1>/*))"
+        assertEquals(BIP49_TESTNET_UPUB, DescriptorUtils.electrumKeyFor(descriptor))
+    }
+
+    @Test
+    fun `electrumKeyFor returns the xpub unchanged for a legacy descriptor`() {
+        assertEquals(BIP32_XPUB, DescriptorUtils.electrumKeyFor("pkh($BIP32_XPUB/<0;1>/*)"))
+    }
+
+    @Test
+    fun `electrumKeyFor roundtrips back to the descriptor's standard key`() {
+        val xpub = DescriptorUtils.convertSlip132ToStandard(realZpub)
+        val zpub = DescriptorUtils.electrumKeyFor("wpkh($xpub/<0;1>/*)")!!
+        assertEquals(xpub, DescriptorUtils.convertSlip132ToStandard(zpub))
+    }
+
+    @Test
+    fun `electrumKeyFor returns null for multisig`() {
+        assertEquals(null, DescriptorUtils.electrumKeyFor(DescriptorUtils.parseMultisigSetupFile(BLUEWALLET_FILE)!!))
+    }
+
+    @Test
+    fun `electrumKeyFor returns null for taproot`() {
+        assertEquals(null, DescriptorUtils.electrumKeyFor("tr($XPUB1/<0;1>/*)"))
+    }
+
+    @Test
+    fun `electrumKeyFor returns null when no extended key is present`() {
+        assertEquals(null, DescriptorUtils.electrumKeyFor("addr(bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4)"))
+    }
+
     // --- parseMultisigSetupFile (BlueWallet / Coldcard) ---
 
     @Test
@@ -290,6 +333,12 @@ class DescriptorUtilsTest {
     }
 
     private companion object {
+        // BIP-49 "Test vectors" §, Account 0 testnet extended public key.
+        const val BIP49_TESTNET_UPUB = "upub5EFU65HtV5TeiSHmZZm7FUffBGy8UKeqp7vw43jYbvZPpoVsgU93oac7Wk3u6moKegAEWtGNF8DehrnHtv21XXEMYRUocHqguyjknFHYfgY"
+
+        // BIP-32 "Test vector 1", chain m extended public key.
+        const val BIP32_XPUB = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+
         const val XPUB1 = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
         const val XPUB2 = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39HjUYTz"
         const val ZPUB1 = "Zpub72NVPmrzYKbwP7Q4bnm59GjzZCCrqoCAmR4yzKbcdHHsKKMUtn8UqggU6VUMgRTqcAubyQ9bn3Tb9n4LB4RnPiEnCqysjCSZY2MCWUMfNsx"

--- a/journeys/README.md
+++ b/journeys/README.md
@@ -140,7 +140,11 @@ action) on open. The snackbar is part of the Scaffold subtree, so its text and a
 | `input_descriptor`          | wallet descriptor field                |
 | `button_update_descriptor`  | "Update descriptor"                    |
 | `button_scan_descriptor`    | "Scan QR" (opens the descriptor scanner)|
-| `button_copy_descriptor`    | a loaded descriptor row — tap to copy the full descriptor to the clipboard |
+| `button_share_descriptor`   | a loaded descriptor row — tap to open the share sheet |
+| `tab_descriptor`            | "Descriptor" tab inside the share sheet (see popup caveat) |
+| `tab_extended_key`         | "Extended key" tab inside the share sheet (see popup caveat) |
+| `button_copy_descriptor`    | Copy button on the share sheet's Descriptor tab |
+| `button_copy_extended_key`  | Copy button on the share sheet's Extended-key tab |
 | `input_network`             | network selector field                 |
 | `toggle_mobile_data`        | "Also use mobile data" switch          |
 | `toggle_peer_flags`         | "Peer country flags" switch — inside its own expandable section, only when advanced features are on |
@@ -148,10 +152,15 @@ action) on open. The snackbar is part of the Scaffold subtree, so its text and a
 | `button_view_logs`          | "View logs" (opens the full-screen log viewer) |
 | `button_export_logs`        | "Export" (share the full debug.log) — inside Developer Tools |
 
-`button_copy_descriptor` is applied to each loaded descriptor row, so the tag repeats once
-per descriptor — target the first when more than one is present. Tapping a row copies the
-**full** descriptor (not the truncated two-line display) and shows a
-"Descriptor copied to clipboard" snackbar.
+`button_share_descriptor` is applied to each loaded descriptor row, so the tag repeats once
+per descriptor — target the first when more than one is present. Tapping a row opens
+`DescriptorShareSheet` (a `ModalBottomSheet`) with two tabs: **Descriptor** (default — the full
+descriptor for modern wallets) and **Extended key** (the SLIP-132 `zpub`/`ypub`/`xpub` Electrum
+expects). Each tab shows a QR, the full key text, and a Copy button. Because the sheet renders in a
+separate window (per the popup caveat below), switch tabs **by text** ("Descriptor" / "Extended
+key"); the `tab_*` / `button_copy_*` tags are for instrumented Compose tests. For a multisig or
+taproot descriptor the Extended-key tab shows a "not available" notice instead of a key. Copying
+shows a "Descriptor copied to clipboard" / "Extended public key copied to clipboard" snackbar.
 
 `button_scan_descriptor` opens `DescriptorScanSheet` (a `ModalBottomSheet`) and, on a
 successful scan, `DescriptorScanConfirmDialog` (an `AlertDialog`). Both render in a

--- a/journeys/load_descriptor.xml
+++ b/journeys/load_descriptor.xml
@@ -1,8 +1,8 @@
 <journey name="Load descriptor">
     <description>
         Pastes a wallet descriptor in Settings, submits it, verifies the descriptor list
-        updates, then copies the loaded descriptor back to the clipboard (issue #113), all
-        without the app crashing.
+        updates, then opens the share sheet and copies the loaded descriptor back to the
+        clipboard (issue #113), all without the app crashing.
     </description>
     <actions>
         <action>Launch the Mandacaru app and wait for the splash screen to dismiss (poll until nav_node is present)</action>
@@ -12,7 +12,8 @@
         <action>Type "wpkh([73c5da0a/84h/1h/0h]tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LgAFKvDsdsBPzMw3RGYbjeMs9dGcTLeUw6f7c/0/*)" into the descriptor field (input_descriptor)</action>
         <action>Tap the Update descriptor button (button_update_descriptor)</action>
         <action>Verify the descriptors list shows the loaded descriptor or a confirmation, and the app has not crashed</action>
-        <action>Tap the loaded descriptor row (button_copy_descriptor; if more than one row is present, target the first) to copy it to the clipboard</action>
+        <action>Tap the loaded descriptor row (button_share_descriptor; if more than one row is present, target the first) to open the share sheet</action>
+        <action>On the share sheet's default "Descriptor" tab, tap the Copy button (target by the "Copy" text; the sheet renders in a separate window so tab/button testTags do not surface)</action>
         <action>Verify a "Descriptor copied to clipboard" snackbar appears (target by text) and the app has not crashed</action>
     </actions>
 </journey>

--- a/journeys/share_descriptor_electrum_key.xml
+++ b/journeys/share_descriptor_electrum_key.xml
@@ -1,0 +1,24 @@
+<journey name="Share descriptor as Electrum key">
+    <description>
+        Loads a native-SegWit descriptor, opens the share sheet from the descriptor row, and
+        verifies both tabs: the default Descriptor tab shows the full descriptor, and the
+        Extended-key tab shows the SLIP-132 zpub Electrum expects (issue #121). The sheet is a
+        ModalBottomSheet, so its tabs and buttons are targeted by visible text, not testTags.
+    </description>
+    <actions>
+        <action>Launch the Mandacaru app and wait for the splash screen to dismiss (poll until nav_node is present)</action>
+        <action>Tap the Settings navigation item (nav_settings)</action>
+        <action>Expand the Descriptors section if it is collapsed</action>
+        <action>Tap the descriptor field (input_descriptor)</action>
+        <action>Type "wpkh([73c5da0a/84h/0h/0h]xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/0/*)" into the descriptor field (input_descriptor)</action>
+        <action>Tap the Update descriptor button (button_update_descriptor)</action>
+        <action>Verify the descriptors list shows the loaded descriptor and the app has not crashed</action>
+        <action>Tap the loaded descriptor row (button_share_descriptor; if more than one row is present, target the first) to open the share sheet</action>
+        <action>Verify the share sheet is open showing two tabs, "Descriptor" and "Extended key" (target by text), with the Descriptor tab selected by default and a QR code visible</action>
+        <action>Verify the "Modern wallets like Sparrow, BlueWallet, Specter" description is shown under the Descriptor tab (target by text)</action>
+        <action>Tap the "Extended key" tab (target by text)</action>
+        <action>Verify the Extended-key tab shows a zpub key beginning with "zpub" (target by text), a QR code, and the "Electrum and older wallets" description</action>
+        <action>Tap the Copy button on the Extended-key tab (target by the "Copy" text)</action>
+        <action>Verify an "Extended public key copied to clipboard" snackbar appears (target by text) and the app has not crashed</action>
+    </actions>
+</journey>


### PR DESCRIPTION
Fixes #121. Close #122.

## Problem

Mandacaru exports descriptors in BIP-380 form, e.g. `wpkh(xpub…/<0;1>/*)`. Electrum has no descriptor support — it parses **SLIP-132 extended keys** and infers the wallet's script type from the key's version-byte prefix (`xpub`=legacy, `ypub`=nested SegWit, `zpub`=native SegWit; testnet `tpub`/`upub`/`vpub`). So pasting Mandacaru's descriptor into Electrum fails with "invalid master key".

Handing Electrum the bare inner `xpub` (as #122 does) is worse: for the common native-SegWit case it makes Electrum track a **legacy** wallet's addresses, silently desyncing — the "insane syncing" from the report. #122 should be closed.

## Solution

The descriptor row's copy button becomes a **Share** button that opens a bottom sheet with two segmented tabs, each with a QR, the full key text, and a copy button:

- **Descriptor** (default) — the full descriptor, for descriptor-native wallets (Sparrow, BlueWallet, Specter).
- **Extended key** — the descriptor's key re-encoded to the SLIP-132 `zpub`/`ypub`/`xpub` (testnet `vpub`/`upub`/`tpub`) matching the script type, for Electrum & older wallets.

For multisig/taproot (no single-key export exists) the Extended-key tab shows a "not available" notice.

`DescriptorUtils.electrumKeyFor()` is the inverse of the existing `convertSlip132ToStandard`, reusing the in-repo base58check machinery and `VERSION_MAGIC_*` constants — **no new dependency** (BDK, the only Bitcoin lib, ships no SLIP-132 encoder by design).

## Testing

- Unit tests for `electrumKeyFor` using verbatim **BIP-84 / BIP-49 / BIP-32** test vectors, plus null cases for multisig/taproot.
- `./gradlew testDebugUnitTest detekt lintDebug assembleDebug` all pass.
- Verified end-to-end on an x86_64 emulator: entered the BIP-84 zpub → app stored `wpkh(xpub…)` (node accepted) → the Extended-key tab reconstructed the **byte-identical original zpub**. Full round trip confirmed.
- New `journeys/share_descriptor_electrum_key.xml`; updated `journeys/load_descriptor.xml` and the README testTag contract.

## Not included (separate issue)

The `RequestCorrupted: inconsistent chunk hex and count` reconnect loop the reporter also hit is an unrelated Rust bug in the `floresta-electrum` `blockchain.block.headers` handler (`count` derived from the requested range instead of the headers actually serialized). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)