### PR TITLE
fix: NPE when viewing the latest block header

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/florestaRPC/response/GetBlockHeaderResponse.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/model/florestaRPC/response/GetBlockHeaderResponse.kt
@@ -14,14 +14,14 @@ data class GetBlockHeaderResponse(
 data class BlockHeaderResult(
     @SerializedName("version")
     val version: Int,
-    @SerializedName("prev_blockhash")
-    val prevBlockhash: String,
-    @SerializedName("merkle_root")
+    @SerializedName("previousblockhash")
+    val prevBlockhash: String? = null,
+    @SerializedName("merkleroot")
     val merkleRoot: String,
     @SerializedName("time")
     val time: Long,
     @SerializedName("bits")
-    val bits: Long,
+    val bits: String,
     @SerializedName("nonce")
     val nonce: Long
 )

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/blockchain/ScreenBlockchain.kt
@@ -520,13 +520,15 @@ internal fun BlockHeaderCard(
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
 
-            BlockDetailRow(
-                label = stringResource(R.string.previous_block),
-                value = header.prevBlockhash,
-                isMonospace = true
-            )
+            header.prevBlockhash?.let { prevBlockhash ->
+                BlockDetailRow(
+                    label = stringResource(R.string.previous_block),
+                    value = prevBlockhash,
+                    isMonospace = true
+                )
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+            }
 
             BlockDetailRow(
                 label = stringResource(R.string.nonce),
@@ -537,7 +539,7 @@ internal fun BlockHeaderCard(
 
             BlockDetailRow(
                 label = stringResource(R.string.bits),
-                value = header.bits.toString()
+                value = header.bits
             )
         }
     }
@@ -588,7 +590,7 @@ private fun Preview() {
                         prevBlockhash = "00000000000000000002abc123def456abc123def456abc123def456abc123de",
                         merkleRoot = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
                         time = 1699564800,
-                        bits = 386089497,
+                        bits = "1702905c",
                         nonce = 2083236893
                     ),
                     blockHash = "00000000000000000001234567890abcdef1234567890abcdef1234567890ab",
@@ -632,7 +634,7 @@ private fun TabletPreview() {
                         prevBlockhash = "00000000000000000002abc123def456abc123def456abc123def456abc123de",
                         merkleRoot = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
                         time = 1699564800,
-                        bits = 386089497,
+                        bits = "1702905c",
                         nonce = 2083236893
                     ),
                     blockHash = "00000000000000000001234567890abcdef1234567890abcdef1234567890ab",

--- a/app/src/test/java/com/github/jvsena42/mandacaru/data/floresta/GetBlockHeaderResponseParsingTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/data/floresta/GetBlockHeaderResponseParsingTest.kt
@@ -1,0 +1,107 @@
+package com.github.jvsena42.mandacaru.data.floresta
+
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockHeaderResponse
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression test for the "View latest block" NullPointerException.
+ *
+ * Tapping "View latest block" calls the `getblockheader` RPC, which Floresta answers
+ * in verbose form by default (verbosity defaults to true, see
+ * `floresta-node/src/json_rpc/server.rs`). The verbose body is a serialized
+ * `corepc_types::v29::GetBlockHeaderVerbose`, whose JSON keys are `merkleroot`,
+ * `previousblockhash` (nullable) and `bits` (a hex *string*, e.g. "1702905c").
+ *
+ * [com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.BlockHeaderResult]
+ * previously declared `@SerializedName("merkle_root")`, `@SerializedName("prev_blockhash")`
+ * and `bits: Long`. Because Gson populates fields by reflection without honouring Kotlin
+ * nullability, the two mismatched keys left the non-null `merkleRoot`/`prevBlockhash`
+ * String fields **null**, and `BlockHeaderCard` then dereferenced them -> NPE. When `bits`
+ * contained a-f hex digits Gson instead threw `NumberFormatException`, surfacing as a
+ * "Failed to parse response" snackbar.
+ *
+ * These vectors deserialize with the same default [Gson] the app uses
+ * (`FlorestaRpcImpl(gson = Gson(), ...)`).
+ */
+class GetBlockHeaderResponseParsingTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun `verbose getblockheader with hex bits deserializes without null fields`() {
+        val response = gson.fromJson(HEX_BITS_RESPONSE, GetBlockHeaderResponse::class.java)
+        val header = response.result
+
+        assertNotNull("merkleRoot must map from the `merkleroot` JSON key", header.merkleRoot)
+        assertNotNull("prevBlockhash must map from the `previousblockhash` JSON key", header.prevBlockhash)
+        assertEquals(
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            header.merkleRoot
+        )
+        assertEquals(
+            "00000000000000000002abc123def456abc123def456abc123def456abc123de",
+            header.prevBlockhash
+        )
+        assertEquals("1702905c", header.bits)
+        assertEquals(536870912, header.version)
+        assertEquals(1699564800L, header.time)
+        assertEquals(2083236893L, header.nonce)
+    }
+
+    @Test
+    fun `verbose getblockheader with all-digit bits deserializes without null fields`() {
+        val response = gson.fromJson(DIGIT_BITS_RESPONSE, GetBlockHeaderResponse::class.java)
+        val header = response.result
+
+        assertNotNull(header.merkleRoot)
+        assertNotNull(header.prevBlockhash)
+        assertEquals("170300000", header.bits)
+    }
+
+    @Test
+    fun `genesis block header without previousblockhash deserializes to null prevBlockhash`() {
+        val response = gson.fromJson(GENESIS_RESPONSE, GetBlockHeaderResponse::class.java)
+        val header = response.result
+
+        assertNotNull(header.merkleRoot)
+        assertNull("Genesis has no previous block, so prevBlockhash must be null", header.prevBlockhash)
+    }
+
+    private companion object {
+        private const val HEX_BITS_RESPONSE = """
+            {"id":1,"jsonrpc":"2.0","result":{
+              "hash":"000000000000000000010a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d",
+              "confirmations":6,"height":943609,"version":536870912,"versionHex":"20000000",
+              "merkleroot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+              "time":1699564800,"mediantime":1699563000,"nonce":2083236893,
+              "bits":"1702905c","target":"00000000000000000002905c00000000000000000000000000000000",
+              "difficulty":1.0,"chainwork":"00","nTx":2500,
+              "previousblockhash":"00000000000000000002abc123def456abc123def456abc123def456abc123de",
+              "nextblockhash":"000000000000000000034d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a"}}
+        """
+
+        private const val DIGIT_BITS_RESPONSE = """
+            {"id":1,"jsonrpc":"2.0","result":{
+              "hash":"000000000000000000010a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d",
+              "confirmations":6,"height":943610,"version":536870912,"versionHex":"20000000",
+              "merkleroot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+              "time":1699564800,"mediantime":1699563000,"nonce":2083236893,
+              "bits":"170300000","target":"00","difficulty":1.0,"chainwork":"00","nTx":2500,
+              "previousblockhash":"00000000000000000002abc123def456abc123def456abc123def456abc123de"}}
+        """
+
+        private const val GENESIS_RESPONSE = """
+            {"id":1,"jsonrpc":"2.0","result":{
+              "hash":"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+              "confirmations":943610,"height":0,"version":1,"versionHex":"00000001",
+              "merkleroot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+              "time":1231006505,"mediantime":1231006505,"nonce":2083236893,
+              "bits":"1d00ffff","target":"00","difficulty":1.0,"chainwork":"00","nTx":1,
+              "nextblockhash":"00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"}}
+        """
+    }
+}


### PR DESCRIPTION
## Problem

A user reported a **NullPointerException when tapping the header of the last block** ("View latest block" on the Blockchain screen).

Tapping the button calls the `getblockheader` RPC, which Floresta answers in **verbose form by default** (`verbosity` defaults to `true` in `floresta-node`'s `server.rs`). The verbose body is a serialized `corepc_types::v29::GetBlockHeaderVerbose`, whose JSON keys are `merkleroot` / `previousblockhash` and whose `bits` is a **hex string** (e.g. `"1702905c"`).

`BlockHeaderResult` expected `@SerializedName("merkle_root")` / `@SerializedName("prev_blockhash")` and `bits: Long`. Since Gson populates non-null Kotlin fields by reflection **without honoring nullability**:

- The mismatched keys left the non-null `merkleRoot`/`prevBlockhash` **null**, and `BlockHeaderCard` dereferenced them → **NPE**. This happens whenever `bits` is all digits (e.g. `"170300000"`), so parsing succeeds.
- When `bits` contains `a`–`f` hex digits (the common case), Gson instead throws `NumberFormatException` → "Failed to parse response" snackbar.

The intermittency (crash depends on the tip block's `nBits`) matches a "sometimes crashes" report.

## Fix

- Map the correct JSON keys (`merkleroot`, `previousblockhash`).
- Type `bits` as `String`.
- Make `prevBlockhash` nullable (`Option<String>` in Floresta — genesis has none) and skip the "Previous block" row when absent.

## Tests

- `GetBlockHeaderResponseParsingTest` — deserializes realistic verbose `getblockheader` responses (hex bits, all-digit bits, and genesis with no `previousblockhash`) using the app's default `Gson()`. Fails against the old model, passes with the fix.
- `./gradlew detekt lintDebug :app:testDebugUnitTest` green.

## Manual verification

Reproduced and verified on an x86_64 emulator: tapping **View latest block** now renders the full Block Header (Merkle Root, Previous Block, Bits, Time, Version, Nonce) with real values and no crash / no parse-error snackbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)