### PR TITLE
fix: stop reporting "Sync 100%" while a wallet rescan is owed (#103)

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/SyncPhase.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/SyncPhase.kt
@@ -1,0 +1,70 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+/**
+ * The single source of truth for "how synced are we", shared by the Node
+ * screen, its tablet layout and the foreground-service notification. Those
+ * three used to derive it independently and drifted: the notification claimed
+ * "Fully synced" for the entire compact-filter sync and for the whole wallet
+ * rescan (jvsena42/mandacaru#103).
+ */
+enum class SyncPhase {
+    HEADERS,
+    STALLED,
+    BLOCKS,
+    FILTERS,
+    WALLET_SCAN,
+    SYNCED,
+}
+
+/**
+ * @param filterSyncDecimal null when compact filters are disabled or started
+ *   from genesis — then there is nothing to wait on.
+ * @param rescanPending a rescan is owed but has not started yet
+ *   (`PreferenceKeys.WALLET_NEEDS_RESCAN`). The service only fires it once the
+ *   chain has been at the tip for a grace window, so without this the UI
+ *   reported 100% while the wallet still had history to find.
+ */
+data class SyncSnapshot(
+    val ibd: Boolean,
+    val progress: Float,
+    val filterSyncDecimal: Float?,
+    val stalled: Boolean,
+    val rescanInProgress: Boolean,
+    val rescanPending: Boolean,
+)
+
+private const val COMPLETE = 1f
+
+fun SyncSnapshot.phase(): SyncPhase = when {
+    ibd && progress == 0f -> SyncPhase.HEADERS
+    stalled -> SyncPhase.STALLED
+    progress < COMPLETE -> SyncPhase.BLOCKS
+    filterSyncDecimal != null && filterSyncDecimal < COMPLETE -> SyncPhase.FILTERS
+    ibd -> SyncPhase.BLOCKS
+    rescanInProgress || rescanPending -> SyncPhase.WALLET_SCAN
+    else -> SyncPhase.SYNCED
+}
+
+/**
+ * Progress of the compact-filter store towards the chain tip. A wallet
+ * birthday shifts the store's start height, so the ratio is measured from
+ * [filtersStart] rather than from genesis.
+ */
+fun computeFilterSyncDecimal(filters: Int?, filtersStart: Int?, height: Int): Float? {
+    if (filters == null) return null
+    val start = filtersStart ?: 0
+    val numerator = (filters - start).coerceAtLeast(0).toFloat()
+    val denominator = (height - start).coerceAtLeast(1).toFloat()
+    return (numerator / denominator).coerceIn(0f, COMPLETE)
+}
+
+/**
+ * Null while the daemon reports no block total — the caller shows an
+ * indeterminate bar rather than a misleading 100%.
+ */
+fun computeRescanProgressDecimal(processed: Int?, total: Int?): Float? {
+    val blocksTotal = total ?: 0
+    if (blocksTotal <= 0) return null
+    val blocksProcessed = (processed ?: 0).toFloat()
+    return (blocksProcessed / blocksTotal.toFloat()).coerceIn(0f, COMPLETE)
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/WalletRescanGate.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/floresta/WalletRescanGate.kt
@@ -1,0 +1,80 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * Decides when the service may fire the follow-up `rescanblockchain` armed by
+ * a descriptor load or a birthday change.
+ *
+ * Filter sync usually catches up to chain sync within seconds, but
+ * matched-block downloads add tail latency, so we wait out [grace] after the
+ * chain reports fully synced before rescanning. Failed attempts back off
+ * geometrically and give up after [maxAttempts]: the UI now reports "not
+ * synced" while a rescan is owed, so an unfixable failure (e.g. filters
+ * disabled) must not pin it there forever.
+ *
+ * Timing runs off a monotonic [TimeSource], not the wall clock — an NTP
+ * correction mid-session would otherwise make a long backoff fire immediately
+ * or never. Deep sleep freezes both this and the poll loop that drives it, so
+ * the two stay consistent.
+ */
+class WalletRescanGate(
+    private val grace: Duration = 60.seconds,
+    private val maxAttempts: Int = 10,
+    private val maxBackoff: Duration = 30.minutes,
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+    private var fullySyncedSince: TimeMark? = null
+    private var lastAttempt: TimeMark? = null
+    private var failures = 0
+
+    fun shouldTrigger(
+        chainFullySynced: Boolean,
+        filtersComplete: Boolean,
+        rescanInProgress: Boolean,
+    ): Boolean {
+        if (!chainFullySynced || !filtersComplete || rescanInProgress) {
+            fullySyncedSince = null
+            return false
+        }
+        val syncedSince = fullySyncedSince ?: timeSource.markNow().also { fullySyncedSince = it }
+        if (syncedSince.elapsedNow() < grace) return false
+        val since = lastAttempt ?: return true
+        return since.elapsedNow() >= backoff()
+    }
+
+    /** The rescan RPC was accepted; the attempt budget resets. */
+    fun onTriggered() {
+        lastAttempt = timeSource.markNow()
+        failures = 0
+    }
+
+    /**
+     * The rescan RPC failed.
+     *
+     * @return true once the budget is spent, meaning the caller should clear
+     *   `WALLET_NEEDS_RESCAN` and stop holding the UI back.
+     */
+    fun onFailed(): Boolean {
+        lastAttempt = timeSource.markNow()
+        failures++
+        return failures >= maxAttempts
+    }
+
+    private fun backoff(): Duration {
+        if (failures <= 0) return grace
+        val doublings = failures.coerceAtMost(MAX_DOUBLINGS)
+        val scaled = grace * (1L shl doublings).toDouble()
+        return minOf(scaled, maxBackoff)
+    }
+
+    private companion object {
+        // Beyond this the backoff has long since hit maxBackoff; capping the
+        // shift keeps it away from Long overflow.
+        const val MAX_DOUBLINGS = 20
+    }
+}

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/FlorestaService.kt
@@ -17,12 +17,17 @@ import com.github.jvsena42.mandacaru.data.PreferenceKeys
 import com.github.jvsena42.mandacaru.data.PreferencesDataSource
 import com.github.jvsena42.mandacaru.data.network.NetworkPolicyManager
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.SyncSnapshot
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoBridgeAutoConnect
+import com.github.jvsena42.mandacaru.domain.floresta.WalletRescanGate
+import com.github.jvsena42.mandacaru.domain.floresta.computeFilterSyncDecimal
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
+import com.github.jvsena42.mandacaru.domain.floresta.computeRescanProgressDecimal
 import com.github.jvsena42.mandacaru.domain.floresta.isLikelyStalled
+import com.github.jvsena42.mandacaru.domain.floresta.phase
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 import com.github.jvsena42.mandacaru.presentation.ui.screens.main.MainActivity
-import com.github.jvsena42.mandacaru.presentation.utils.toSyncPercentageString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -35,8 +40,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
-import java.text.NumberFormat
 import java.util.concurrent.atomic.AtomicBoolean
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.Result as BlockchainInfo
 
 class FlorestaService : Service() {
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -50,7 +55,7 @@ class FlorestaService : Service() {
     private var wifiStateJob: Job? = null
     @Volatile private var waitingForWifi = false
     private var startupSeedDone = false
-    private var fullySyncedSinceMs: Long? = null
+    private val walletRescanGate = WalletRescanGate()
     private val rescanInFlight = AtomicBoolean(false)
 
     companion object {
@@ -67,10 +72,6 @@ class FlorestaService : Service() {
         private const val COLOR_SYNCED = "#006D37"
         private const val FULL_SYNC_THRESHOLD = 1.0f
         private const val PERCENTAGE_MULTIPLIER = 100
-        // Filter sync usually catches up to chain sync within seconds, but
-        // matched-block downloads add tail latency. Wait this long after the
-        // chain reports fully synced before triggering the descriptor rescan.
-        private const val FULL_SYNC_GRACE_MS = 60_000L
     }
 
     override fun onCreate() {
@@ -187,49 +188,63 @@ class FlorestaService : Service() {
                 delay(NOTIFICATION_POLL_INTERVAL_MS)
                 runSuspendCatching {
                     florestaRpc.getBlockchainInfo().collect { result ->
-                        result.onSuccess { data ->
-                            val peers = florestaRpc.getPeerInfo().firstOrNull()
-                                ?.getOrNull()?.result.orEmpty()
-                            updateSyncNotification(
-                                progress = data.result.progress,
-                                height = data.result.height,
-                                ibd = data.result.ibd,
-                                peers = peers,
-                            )
-                            if (!startupSeedDone) {
-                                startupSeedDone = true
-                                launch { utreexoBridgeAutoConnect.seedOnStartup() }
-                            } else {
-                                launch { utreexoBridgeAutoConnect.ensureUtreexoPeers() }
-                            }
-                            val stalled = isLikelyStalled(
-                                progress = data.result.progress,
-                                ibd = data.result.ibd,
-                                ourHeight = data.result.height,
-                                peers = peers,
-                            )
-                            // Compact filters must be downloaded all the way to
-                            // the tip before a rescan can find every relevant
-                            // block. `filters` null means cfilters are disabled
-                            // or started from genesis — then there's nothing to
-                            // wait on. When present, require filters >= height.
-                            val filtersComplete = data.result.filters
-                                ?.let { it >= data.result.height && data.result.height > 0 }
-                                ?: true
-                            maybeTriggerWalletRescan(
-                                progress = data.result.progress,
-                                ibd = data.result.ibd,
-                                stalled = stalled,
-                                filtersComplete = filtersComplete,
-                                rescanInProgress = data.result.rescanInProgress,
-                            )
-                        }
+                        result.onSuccess { data -> onBlockchainInfo(data.result) }
                     }
                 }.onFailure { e ->
                     Log.d(TAG, "Notification poll failed: ${e.message}")
                 }
             }
         }
+    }
+
+    private suspend fun onBlockchainInfo(info: BlockchainInfo) {
+        val peers = florestaRpc.getPeerInfo().firstOrNull()?.getOrNull()?.result.orEmpty()
+        val stalled = isLikelyStalled(
+            progress = info.progress,
+            ibd = info.ibd,
+            ourHeight = info.height,
+            peers = peers,
+        )
+        val filterSyncDecimal = computeFilterSyncDecimal(
+            filters = info.filters,
+            filtersStart = info.filtersStart,
+            height = info.height,
+        )
+        val snapshot = SyncSnapshot(
+            ibd = info.ibd,
+            progress = info.progress,
+            filterSyncDecimal = filterSyncDecimal,
+            stalled = stalled,
+            rescanInProgress = info.rescanInProgress,
+            rescanPending = preferencesDataSource
+                .getBoolean(PreferenceKeys.WALLET_NEEDS_RESCAN, false),
+        )
+
+        updateSyncNotification(
+            snapshot = snapshot,
+            height = info.height,
+            peers = peers,
+            rescanProgressDecimal = computeRescanProgressDecimal(
+                processed = info.rescanBlocksProcessed,
+                total = info.rescanBlocksTotal,
+            ),
+        )
+
+        if (!startupSeedDone) {
+            startupSeedDone = true
+            ioScope.launch { utreexoBridgeAutoConnect.seedOnStartup() }
+        } else {
+            ioScope.launch { utreexoBridgeAutoConnect.ensureUtreexoPeers() }
+        }
+
+        maybeTriggerWalletRescan(
+            snapshot = snapshot,
+            // Compact filters must be downloaded all the way to the tip before
+            // a rescan can find every relevant block. A null decimal means
+            // cfilters are disabled or started from genesis — nothing to wait on.
+            filtersComplete = filterSyncDecimal == null ||
+                    filterSyncDecimal >= FULL_SYNC_THRESHOLD,
+        )
     }
 
     /**
@@ -242,51 +257,55 @@ class FlorestaService : Service() {
      * [PreferenceKeys.WALLET_NEEDS_RESCAN] flag so it only fires once.
      *
      * Skips while a rescan is already running so we never stack duplicates.
+     * The UI reports "not synced" for as long as the flag is set, so a rescan
+     * that keeps failing gives up rather than pinning it there forever.
      */
-    private fun maybeTriggerWalletRescan(
-        progress: Float,
-        ibd: Boolean,
-        stalled: Boolean,
-        filtersComplete: Boolean,
-        rescanInProgress: Boolean,
-    ) {
-        val chainFullySynced = !ibd && progress >= FULL_SYNC_THRESHOLD && !stalled
-        if (!chainFullySynced || !filtersComplete || rescanInProgress) {
-            fullySyncedSinceMs = null
-            return
-        }
-        val now = System.currentTimeMillis()
-        val syncedSince = fullySyncedSinceMs ?: now.also { fullySyncedSinceMs = it }
-        if (now - syncedSince < FULL_SYNC_GRACE_MS) return
+    private fun maybeTriggerWalletRescan(snapshot: SyncSnapshot, filtersComplete: Boolean) {
+        val chainFullySynced = !snapshot.ibd &&
+                snapshot.progress >= FULL_SYNC_THRESHOLD &&
+                !snapshot.stalled
+        // Called unconditionally so the gate keeps tracking how long we have
+        // been at the tip, even while no rescan is owed.
+        val shouldTrigger = walletRescanGate.shouldTrigger(
+            chainFullySynced = chainFullySynced,
+            filtersComplete = filtersComplete,
+            rescanInProgress = snapshot.rescanInProgress,
+        )
+        if (!shouldTrigger || !snapshot.rescanPending) return
         if (!rescanInFlight.compareAndSet(false, true)) return
 
         ioScope.launch {
             try {
-                val needsRescan = preferencesDataSource
-                    .getBoolean(PreferenceKeys.WALLET_NEEDS_RESCAN, false)
-                if (!needsRescan) return@launch
-
                 Log.i(TAG, "Triggering rescanblockchain after wallet-birthday change")
                 val result = florestaRpc.rescan().firstOrNull()
                 if (result?.isSuccess == true) {
+                    walletRescanGate.onTriggered()
                     preferencesDataSource.setBoolean(PreferenceKeys.WALLET_NEEDS_RESCAN, false)
                     Log.i(TAG, "Wallet rescan triggered; flag cleared")
                 } else {
                     Log.w(TAG, "rescan failed: ${result?.exceptionOrNull()?.message}")
+                    giveUpOnRescanIfExhausted()
                 }
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 Log.w(TAG, "Wallet rescan trigger failed: ${e.message}")
+                giveUpOnRescanIfExhausted()
             } finally {
                 rescanInFlight.set(false)
             }
         }
     }
 
+    private suspend fun giveUpOnRescanIfExhausted() {
+        if (!walletRescanGate.onFailed()) return
+        preferencesDataSource.setBoolean(PreferenceKeys.WALLET_NEEDS_RESCAN, false)
+        Log.w(TAG, "Wallet rescan gave up after repeated failures; flag cleared")
+    }
+
     private fun updateSyncNotification(
-        progress: Float,
+        snapshot: SyncSnapshot,
         height: Int,
-        ibd: Boolean,
         peers: List<PeerInfoResult>,
+        rescanProgressDecimal: Float?,
     ) {
         val notificationManager = getSystemService(NotificationManager::class.java) ?: return
 
@@ -314,9 +333,18 @@ class FlorestaService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val isHeaderSync = ibd && progress == 0f
-        val headerDecimal = if (isHeaderSync) computeHeaderSyncProgress(height, peers) else null
-        val stalled = isLikelyStalled(progress = progress, ibd = ibd, ourHeight = height, peers = peers)
+        val phase = snapshot.phase()
+        val content = syncNotificationContent(
+            phase = phase,
+            snapshot = snapshot,
+            headerSyncDecimal = if (phase == SyncPhase.HEADERS) {
+                computeHeaderSyncProgress(height, peers)
+            } else {
+                null
+            },
+            rescanProgressDecimal = rescanProgressDecimal,
+            height = height,
+        )
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Mandacaru")
@@ -327,58 +355,22 @@ class FlorestaService : Service() {
             .setOngoing(true)
             .setContentIntent(openAppPendingIntent)
             .addAction(R.drawable.ic_x, "Stop", stopPendingIntent)
-            .applySyncState(progress, height, isHeaderSync, headerDecimal, stalled)
+            .applySyncState(content)
 
         notificationManager.notify(FLORESTA_NOTIFICATION_ID, builder.build())
     }
 
     private fun NotificationCompat.Builder.applySyncState(
-        progress: Float,
-        height: Int,
-        isHeaderSync: Boolean,
-        headerDecimal: Float?,
-        stalled: Boolean,
+        content: SyncNotificationContent,
     ): NotificationCompat.Builder {
+        setContentText(content.contentText)
+            .setSubText(content.subText)
+            .setColor(if (content.synced) COLOR_SYNCED.toColorInt() else COLOR_PRIMARY.toColorInt())
+            .setColorized(true)
         when {
-            headerDecimal != null -> {
-                val label = headerDecimal.toSyncPercentageString()
-                val barProgress = (headerDecimal * PERCENTAGE_MULTIPLIER).toInt()
-                setContentText("Syncing headers: $label%")
-                    .setSubText("$label% headers")
-                    .setProgress(PERCENTAGE_MULTIPLIER, barProgress, false)
-                    .setColor(COLOR_PRIMARY.toColorInt())
-                    .setColorized(true)
-            }
-            isHeaderSync -> {
-                setContentText("Syncing headers…")
-                    .setSubText("Connecting to peers")
-                    .setProgress(0, 0, true)
-                    .setColor(COLOR_PRIMARY.toColorInt())
-                    .setColorized(true)
-            }
-            stalled -> {
-                val formattedHeight = NumberFormat.getNumberInstance().format(height)
-                setContentText("Sync stalled at block #$formattedHeight")
-                    .setSubText("Storage may be unhealthy")
-                    .setColor(COLOR_PRIMARY.toColorInt())
-                    .setColorized(true)
-            }
-            progress < FULL_SYNC_THRESHOLD -> {
-                val label = progress.toSyncPercentageString()
-                val barProgress = (progress * PERCENTAGE_MULTIPLIER).toInt()
-                setContentText("Syncing blocks: $label%")
-                    .setSubText("$label% blocks")
-                    .setProgress(PERCENTAGE_MULTIPLIER, barProgress, false)
-                    .setColor(COLOR_PRIMARY.toColorInt())
-                    .setColorized(true)
-            }
-            else -> {
-                val formattedHeight = NumberFormat.getNumberInstance().format(height)
-                setContentText("Synced - Block #$formattedHeight")
-                    .setSubText("Fully synced")
-                    .setColor(COLOR_SYNCED.toColorInt())
-                    .setColorized(true)
-            }
+            content.indeterminate -> setProgress(0, 0, true)
+            content.progressPercent != null ->
+                setProgress(PERCENTAGE_MULTIPLIER, content.progressPercent, false)
         }
         return this
     }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationContent.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationContent.kt
@@ -1,0 +1,82 @@
+package com.github.jvsena42.mandacaru.presentation.service
+
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.SyncSnapshot
+import com.github.jvsena42.mandacaru.presentation.utils.toSyncPercentageString
+import java.text.NumberFormat
+
+/**
+ * What the foreground-service notification should say for a given
+ * [SyncPhase]. Kept free of Android types so the mapping — in particular
+ * "never claim synced outside [SyncPhase.SYNCED]" — is unit-testable.
+ */
+data class SyncNotificationContent(
+    val contentText: String,
+    val subText: String,
+    val progressPercent: Int?,
+    val indeterminate: Boolean,
+    val synced: Boolean,
+)
+
+private const val PERCENTAGE_MULTIPLIER = 100
+
+fun syncNotificationContent(
+    phase: SyncPhase,
+    snapshot: SyncSnapshot,
+    headerSyncDecimal: Float?,
+    rescanProgressDecimal: Float?,
+    height: Int,
+): SyncNotificationContent = when (phase) {
+    SyncPhase.HEADERS -> headerSyncDecimal
+        ?.let { determinate(it, "Syncing headers", "headers") }
+        ?: indeterminate("Syncing headers…", "Connecting to peers")
+
+    SyncPhase.STALLED -> SyncNotificationContent(
+        contentText = "Sync stalled at block #${formatHeight(height)}",
+        subText = "Storage may be unhealthy",
+        progressPercent = null,
+        indeterminate = false,
+        synced = false,
+    )
+
+    SyncPhase.BLOCKS -> determinate(snapshot.progress, "Syncing blocks", "blocks")
+
+    SyncPhase.FILTERS -> determinate(
+        decimal = snapshot.filterSyncDecimal ?: 0f,
+        label = "Syncing filters",
+        subLabel = "filters",
+    )
+
+    SyncPhase.WALLET_SCAN -> rescanProgressDecimal
+        ?.let { determinate(it, "Scanning wallet", "wallet scan") }
+        ?: indeterminate("Scanning wallet…", "Finding your transactions")
+
+    SyncPhase.SYNCED -> SyncNotificationContent(
+        contentText = "Synced - Block #${formatHeight(height)}",
+        subText = "Fully synced",
+        progressPercent = null,
+        indeterminate = false,
+        synced = true,
+    )
+}
+
+private fun determinate(decimal: Float, label: String, subLabel: String): SyncNotificationContent {
+    val percentage = decimal.toSyncPercentageString()
+    return SyncNotificationContent(
+        contentText = "$label: $percentage%",
+        subText = "$percentage% $subLabel",
+        progressPercent = (decimal * PERCENTAGE_MULTIPLIER).toInt(),
+        indeterminate = false,
+        synced = false,
+    )
+}
+
+private fun indeterminate(contentText: String, subText: String) = SyncNotificationContent(
+    contentText = contentText,
+    subText = subText,
+    progressPercent = null,
+    indeterminate = true,
+    synced = false,
+)
+
+private fun formatHeight(height: Int): String = NumberFormat.getNumberInstance().format(height)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -21,6 +21,7 @@ data class NodeUiState(
     val isStalled: Boolean = false,
     val ibd: Boolean = true,
     val rescanInProgress: Boolean = false,
+    val walletRescanPending: Boolean = false,
     val rescanProgressDecimal: Float? = null,
     val rescanProgressPercentage: String = "0.00",
     val rescanBlocksProcessed: Int = 0,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -12,7 +12,9 @@ import com.github.jvsena42.mandacaru.data.floresta.toFlorestaNetwork
 import com.github.jvsena42.mandacaru.data.network.NetworkPolicy
 import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
 import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
+import com.github.jvsena42.mandacaru.domain.floresta.computeFilterSyncDecimal
 import com.github.jvsena42.mandacaru.domain.floresta.computeHeaderSyncProgress
+import com.github.jvsena42.mandacaru.domain.floresta.computeRescanProgressDecimal
 import com.github.jvsena42.mandacaru.domain.floresta.hasUtreexoServiceFlag
 import com.github.jvsena42.mandacaru.domain.floresta.isLikelyStalled
 import com.github.jvsena42.mandacaru.domain.geoip.PeerCountryLookup
@@ -60,17 +62,25 @@ class NodeViewModel(
 
     private fun getInLoop() {
         viewModelScope.launch(ioDispatcher) {
-            refreshAdvancedFeatures()
+            refreshPreferences()
             getInfo()
             delay(10.seconds)
             getInLoop()
         }
     }
 
-    private suspend fun refreshAdvancedFeatures() {
+    private suspend fun refreshPreferences() {
         val enabled = preferencesDataSource
             .getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, false)
-        _uiState.update { it.copy(enableAdvancedFeatures = enabled) }
+        // A rescan armed by a descriptor load or birthday change only fires
+        // once the chain has been at the tip for a grace window. Until it
+        // does, the wallet still has history to find and we must not claim
+        // to be fully synced.
+        val rescanPending = preferencesDataSource
+            .getBoolean(PreferenceKeys.WALLET_NEEDS_RESCAN, false)
+        _uiState.update {
+            it.copy(enableAdvancedFeatures = enabled, walletRescanPending = rescanPending)
+        }
     }
 
     private fun getInfo() {
@@ -78,21 +88,17 @@ class NodeViewModel(
             florestaRpc.getBlockchainInfo().collect { result ->
                 result.onSuccess { data ->
                     val filterHeight = data.result.filters
-                    val filterStart = data.result.filtersStart ?: 0
-                    val filterDecimal = filterHeight?.let { fh ->
-                        val numerator = (fh - filterStart).coerceAtLeast(0).toFloat()
-                        val denominator = (data.result.height - filterStart)
-                            .coerceAtLeast(1)
-                            .toFloat()
-                        (numerator / denominator).coerceIn(0f, 1f)
-                    }
+                    val filterDecimal = computeFilterSyncDecimal(
+                        filters = filterHeight,
+                        filtersStart = data.result.filtersStart,
+                        height = data.result.height,
+                    )
                     val rescanTotal = data.result.rescanBlocksTotal ?: 0
                     val rescanProcessed = data.result.rescanBlocksProcessed ?: 0
-                    val rescanDecimal = if (rescanTotal > 0) {
-                        (rescanProcessed.toFloat() / rescanTotal.toFloat()).coerceIn(0f, 1f)
-                    } else {
-                        null
-                    }
+                    val rescanDecimal = computeRescanProgressDecimal(
+                        processed = rescanProcessed,
+                        total = rescanTotal,
+                    )
                     _uiState.update {
                         it.copy(
                             blockHeight = NumberFormat.getNumberInstance().format(data.result.height),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNode.kt
@@ -96,6 +96,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.text.NumberFormat
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.phase
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.PeerInfoResult
 import com.github.jvsena42.mandacaru.presentation.ui.components.ExpandableHeader
 import com.github.jvsena42.mandacaru.presentation.ui.theme.MandacaruTheme
@@ -285,31 +287,19 @@ fun ScreenNode(
     var peerToDisconnect by remember { mutableStateOf<String?>(null) }
     var showPingConfirmation by remember { mutableStateOf(false) }
 
-    val isHeaderSync = uiState.ibd && uiState.syncDecimal == 0f
-    val isStalled = uiState.isStalled
+    // Shared with the tablet layout and the foreground-service notification so
+    // the three can't disagree about how synced we are.
+    val syncPhase = uiState.toSyncSnapshot().phase()
+    val isHeaderSync = syncPhase == SyncPhase.HEADERS
+    val isStalled = syncPhase == SyncPhase.STALLED
     val headerSyncDecimal = uiState.headerSyncDecimal
     val filterSyncDecimal = uiState.filterSyncDecimal
-    val isFilterSync = !isHeaderSync
-            && !isStalled
-            && uiState.syncDecimal >= 1f
-            && filterSyncDecimal != null
-            && filterSyncDecimal < 1f
+    val isFilterSync = syncPhase == SyncPhase.FILTERS
     // Filters reaching the tip doesn't mean the wallet is scanned; while a
-    // rescan runs the node is still finding the wallet's transactions, so we
-    // surface that instead of claiming "Synced".
-    val isWalletScanning = !isHeaderSync
-            && !isStalled
-            && uiState.syncDecimal >= 1f
-            && (filterSyncDecimal == null || filterSyncDecimal >= 1f)
-            && uiState.rescanInProgress
-    val syncTitleRes = when {
-        isHeaderSync -> R.string.syncing_headers_title
-        isStalled -> R.string.sync_stalled_title
-        isFilterSync -> R.string.syncing_filters_title
-        uiState.ibd -> R.string.syncing_blocks_title
-        isWalletScanning -> R.string.scanning_wallet_title
-        else -> R.string.sync
-    }
+    // rescan runs — or is still owed — the node has transactions left to find,
+    // so we surface that instead of claiming "Synced".
+    val isWalletScanning = syncPhase == SyncPhase.WALLET_SCAN
+    val syncTitleRes = syncPhase.titleRes()
 
     ScreenNodeAlertDialogs(
         peerToDisconnect = peerToDisconnect,
@@ -352,11 +342,7 @@ fun ScreenNode(
         if (layout.useTwoPane) {
             TabletNodeDashboard(
                 uiState = uiState,
-                isHeaderSync = isHeaderSync,
-                isFilterSync = isFilterSync,
-                isStalled = isStalled,
-                isWalletScanning = isWalletScanning,
-                syncTitleRes = syncTitleRes,
+                phase = syncPhase,
                 onPingClick = { showPingConfirmation = true },
                 onRequestDisconnect = { peerToDisconnect = it },
                 onClickScan = onClickScan,
@@ -410,7 +396,7 @@ fun ScreenNode(
                         filterSyncPercentage = uiState.filterSyncPercentage,
                         syncPercentage = uiState.syncPercentage,
                         syncDecimal = uiState.syncDecimal,
-                        rescanInProgress = uiState.rescanInProgress,
+                        phase = syncPhase,
                         rescanProgressDecimal = uiState.rescanProgressDecimal,
                         rescanProgressPercentage = uiState.rescanProgressPercentage,
                         rescanBlocksProcessed = uiState.rescanBlocksProcessed,
@@ -760,58 +746,6 @@ private fun DiagnosticsCard(
     }
 }
 
-private data class SyncStepStates(
-    val headers: StepState,
-    val blocks: StepState,
-    val filters: StepState?,
-    val allDone: Boolean,
-)
-
-private fun blocksStepState(
-    headersDone: Boolean,
-    blocksDone: Boolean,
-    walletScanning: Boolean,
-    hasFiltersStep: Boolean,
-): StepState = when {
-    walletScanning && !hasFiltersStep -> StepState.Current
-    blocksDone -> StepState.Done
-    headersDone -> StepState.Current
-    else -> StepState.Pending
-}
-
-private fun filtersStepState(
-    hasFiltersStep: Boolean,
-    walletScanning: Boolean,
-    filtersDownloaded: Boolean,
-    blocksDone: Boolean,
-): StepState? = when {
-    !hasFiltersStep -> null
-    walletScanning -> StepState.Current
-    filtersDownloaded && blocksDone -> StepState.Done
-    blocksDone -> StepState.Current
-    else -> StepState.Pending
-}
-
-private fun computeSyncStepStates(
-    isHeaderSync: Boolean,
-    syncDecimal: Float,
-    filterSyncDecimal: Float?,
-    rescanInProgress: Boolean,
-): SyncStepStates {
-    val hasFiltersStep = filterSyncDecimal != null
-    val headersDone = !isHeaderSync
-    val blocksDone = syncDecimal >= 1f
-    val filtersDownloaded = filterSyncDecimal == null || filterSyncDecimal >= 1f
-    // A running rescan means the wallet isn't fully scanned yet: keep the last
-    // step Current and don't report everything done.
-    val walletScanning = headersDone && blocksDone && filtersDownloaded && rescanInProgress
-    val headers = if (headersDone) StepState.Done else StepState.Current
-    val blocks = blocksStepState(headersDone, blocksDone, walletScanning, hasFiltersStep)
-    val filters = filtersStepState(hasFiltersStep, walletScanning, filtersDownloaded, blocksDone)
-    val allDone = headersDone && blocksDone && filtersDownloaded && !rescanInProgress
-    return SyncStepStates(headers, blocks, filters, allDone)
-}
-
 private data class SyncProgressInputs(
     val isStalled: Boolean,
     val isHeaderSync: Boolean,
@@ -926,7 +860,7 @@ private fun SyncProgressCard(
     filterSyncPercentage: String,
     syncPercentage: String,
     syncDecimal: Float,
-    rescanInProgress: Boolean,
+    phase: SyncPhase,
     rescanProgressDecimal: Float?,
     rescanProgressPercentage: String,
     rescanBlocksProcessed: Int,
@@ -953,8 +887,7 @@ private fun SyncProgressCard(
         label = "syncProgress",
     )
     val percentageText = inputs.percentageText()
-    val steps =
-        computeSyncStepStates(isHeaderSync, syncDecimal, filterSyncDecimal, rescanInProgress)
+    val steps = computeSyncStepStates(phase, syncDecimal, filterSyncDecimal)
 
     Card(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNodeTablet.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/ScreenNodeTablet.kt
@@ -48,16 +48,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
 import java.text.NumberFormat
 
 @Composable
 internal fun TabletNodeDashboard(
     uiState: NodeUiState,
-    isHeaderSync: Boolean,
-    isFilterSync: Boolean,
-    isStalled: Boolean,
-    isWalletScanning: Boolean,
-    syncTitleRes: Int,
+    phase: SyncPhase,
     onPingClick: () -> Unit,
     onRequestDisconnect: (String) -> Unit,
     onClickScan: () -> Unit,
@@ -69,6 +66,7 @@ internal fun TabletNodeDashboard(
     onClickShareExport: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isHeaderSync = phase == SyncPhase.HEADERS
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -76,18 +74,11 @@ internal fun TabletNodeDashboard(
         if (uiState.ibd && uiState.utreexoPeerCount == 0) {
             UtreexoWarningCard()
         }
-        if (isStalled) {
+        if (phase == SyncPhase.STALLED) {
             SyncStalledWarningCard()
         }
 
-        HeroStatusBand(
-            uiState = uiState,
-            isHeaderSync = isHeaderSync,
-            isFilterSync = isFilterSync,
-            isStalled = isStalled,
-            isWalletScanning = isWalletScanning,
-            syncTitleRes = syncTitleRes,
-        )
+        HeroStatusBand(uiState = uiState, phase = phase)
 
         Row(
             modifier = Modifier
@@ -144,12 +135,13 @@ internal fun TabletNodeDashboard(
 @Composable
 private fun HeroStatusBand(
     uiState: NodeUiState,
-    isHeaderSync: Boolean,
-    isFilterSync: Boolean,
-    isStalled: Boolean,
-    isWalletScanning: Boolean,
-    syncTitleRes: Int,
+    phase: SyncPhase,
 ) {
+    val isHeaderSync = phase == SyncPhase.HEADERS
+    val isFilterSync = phase == SyncPhase.FILTERS
+    val isStalled = phase == SyncPhase.STALLED
+    val isWalletScanning = phase == SyncPhase.WALLET_SCAN
+    val syncTitleRes = phase.titleRes()
     val rawDecimal: Float? = when {
         isStalled -> 0f
         isHeaderSync && uiState.headerSyncDecimal != null -> uiState.headerSyncDecimal
@@ -177,25 +169,12 @@ private fun HeroStatusBand(
         else -> "${uiState.syncPercentage}%"
     }
 
-    val hasFiltersStep = uiState.filterSyncDecimal != null
-    val headersDone = !isHeaderSync
-    val blocksDone = uiState.syncDecimal >= 1f
-    val filtersDone = uiState.filterSyncDecimal == null || uiState.filterSyncDecimal >= 1f
-    // A running wallet rescan means we're not fully synced yet, even once
-    // filters reached the tip.
-    val allDone = headersDone && blocksDone && filtersDone && !uiState.rescanInProgress
-    val headersState = if (headersDone) StepState.Done else StepState.Current
-    val blocksState = when {
-        blocksDone -> StepState.Done
-        headersDone -> StepState.Current
-        else -> StepState.Pending
-    }
-    val filtersState: StepState? = when {
-        !hasFiltersStep -> null
-        filtersDone && blocksDone -> StepState.Done
-        blocksDone -> StepState.Current
-        else -> StepState.Pending
-    }
+    val steps = computeSyncStepStates(
+        phase = phase,
+        syncDecimal = uiState.syncDecimal,
+        filterSyncDecimal = uiState.filterSyncDecimal,
+    )
+    val allDone = steps.allDone
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -247,9 +226,9 @@ private fun HeroStatusBand(
                         shrinkVertically(animationSpec = tween(300)),
                 ) {
                     SyncStepper(
-                        headersState = headersState,
-                        blocksState = blocksState,
-                        filtersState = filtersState,
+                        headersState = steps.headers,
+                        blocksState = steps.blocks,
+                        filtersState = steps.filters,
                     )
                 }
                 HorizontalDivider(

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/SyncPhaseUi.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/SyncPhaseUi.kt
@@ -1,0 +1,77 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import androidx.annotation.StringRes
+import com.github.jvsena42.mandacaru.R
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.SyncSnapshot
+
+fun NodeUiState.toSyncSnapshot() = SyncSnapshot(
+    ibd = ibd,
+    progress = syncDecimal,
+    filterSyncDecimal = filterSyncDecimal,
+    stalled = isStalled,
+    rescanInProgress = rescanInProgress,
+    rescanPending = walletRescanPending,
+)
+
+@StringRes
+fun SyncPhase.titleRes(): Int = when (this) {
+    SyncPhase.HEADERS -> R.string.syncing_headers_title
+    SyncPhase.STALLED -> R.string.sync_stalled_title
+    SyncPhase.BLOCKS -> R.string.syncing_blocks_title
+    SyncPhase.FILTERS -> R.string.syncing_filters_title
+    SyncPhase.WALLET_SCAN -> R.string.scanning_wallet_title
+    SyncPhase.SYNCED -> R.string.sync
+}
+
+internal data class SyncStepStates(
+    val headers: StepState,
+    val blocks: StepState,
+    val filters: StepState?,
+    val allDone: Boolean,
+)
+
+private fun blocksStepState(
+    headersDone: Boolean,
+    blocksDone: Boolean,
+    walletScanning: Boolean,
+    hasFiltersStep: Boolean,
+): StepState = when {
+    walletScanning && !hasFiltersStep -> StepState.Current
+    blocksDone -> StepState.Done
+    headersDone -> StepState.Current
+    else -> StepState.Pending
+}
+
+private fun filtersStepState(
+    hasFiltersStep: Boolean,
+    walletScanning: Boolean,
+    filtersDownloaded: Boolean,
+    blocksDone: Boolean,
+): StepState? = when {
+    !hasFiltersStep -> null
+    walletScanning -> StepState.Current
+    filtersDownloaded && blocksDone -> StepState.Done
+    blocksDone -> StepState.Current
+    else -> StepState.Pending
+}
+
+internal fun computeSyncStepStates(
+    phase: SyncPhase,
+    syncDecimal: Float,
+    filterSyncDecimal: Float?,
+): SyncStepStates {
+    val hasFiltersStep = filterSyncDecimal != null
+    val headersDone = phase != SyncPhase.HEADERS
+    val blocksDone = syncDecimal >= COMPLETE
+    val filtersDownloaded = filterSyncDecimal == null || filterSyncDecimal >= COMPLETE
+    // A rescan that is running — or still owed — means the wallet isn't fully
+    // scanned yet: keep the last step Current and don't report everything done.
+    val walletScanning = phase == SyncPhase.WALLET_SCAN
+    val headers = if (headersDone) StepState.Done else StepState.Current
+    val blocks = blocksStepState(headersDone, blocksDone, walletScanning, hasFiltersStep)
+    val filters = filtersStepState(hasFiltersStep, walletScanning, filtersDownloaded, blocksDone)
+    return SyncStepStates(headers, blocks, filters, allDone = phase == SyncPhase.SYNCED)
+}
+
+private const val COMPLETE = 1f

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/SyncDecimalsTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/SyncDecimalsTest.kt
@@ -1,0 +1,93 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SyncDecimalsTest {
+
+    @Test
+    fun `filter progress is measured from the store's start height`() {
+        // A 2017 wallet birthday starts the filter store at 450k, so being at
+        // 475k of 500k is halfway, not 95%.
+        assertEquals(
+            0.5f,
+            computeFilterSyncDecimal(filters = 475_000, filtersStart = 450_000, height = 500_000)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `filter progress without a start height measures from genesis`() {
+        assertEquals(
+            0.5f,
+            computeFilterSyncDecimal(filters = 250_000, filtersStart = null, height = 500_000)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `filters at or past the tip are complete`() {
+        assertEquals(
+            1f,
+            computeFilterSyncDecimal(filters = 500_000, filtersStart = 0, height = 500_000)!!,
+            TOLERANCE,
+        )
+        assertEquals(
+            1f,
+            computeFilterSyncDecimal(filters = 500_010, filtersStart = 0, height = 500_000)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `filters behind the start height clamp to zero rather than going negative`() {
+        assertEquals(
+            0f,
+            computeFilterSyncDecimal(filters = 100, filtersStart = 450_000, height = 500_000)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `absent filters mean there is nothing to wait on`() {
+        assertNull(computeFilterSyncDecimal(filters = null, filtersStart = null, height = 500_000))
+    }
+
+    @Test
+    fun `zero height does not divide by zero`() {
+        assertEquals(
+            0f,
+            computeFilterSyncDecimal(filters = 0, filtersStart = 0, height = 0)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `rescan progress is null until the daemon reports a block total`() {
+        assertNull(computeRescanProgressDecimal(processed = 0, total = 0))
+        assertNull(computeRescanProgressDecimal(processed = null, total = null))
+    }
+
+    @Test
+    fun `rescan progress is the processed ratio`() {
+        assertEquals(
+            0.25f,
+            computeRescanProgressDecimal(processed = 80, total = 320)!!,
+            TOLERANCE,
+        )
+    }
+
+    @Test
+    fun `rescan progress clamps at one`() {
+        assertEquals(
+            1f,
+            computeRescanProgressDecimal(processed = 400, total = 319)!!,
+            TOLERANCE,
+        )
+    }
+
+    private companion object {
+        const val TOLERANCE = 0.0001f
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/SyncPhaseTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/SyncPhaseTest.kt
@@ -1,0 +1,95 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The phase table behind jvsena42/mandacaru#103: the app reported
+ * "Sync 100.00%" while a wallet rescan was still owed, the user reconnected
+ * their Electrum wallets on the strength of it, and got partial history.
+ */
+class SyncPhaseTest {
+
+    private fun snapshot(
+        ibd: Boolean = false,
+        progress: Float = 1f,
+        filterSyncDecimal: Float? = 1f,
+        stalled: Boolean = false,
+        rescanInProgress: Boolean = false,
+        rescanPending: Boolean = false,
+    ) = SyncSnapshot(
+        ibd = ibd,
+        progress = progress,
+        filterSyncDecimal = filterSyncDecimal,
+        stalled = stalled,
+        rescanInProgress = rescanInProgress,
+        rescanPending = rescanPending,
+    )
+
+    @Test
+    fun `rescan owed but not started yet is not synced - issue 103 steps 13 and 19`() {
+        assertEquals(
+            SyncPhase.WALLET_SCAN,
+            snapshot(rescanInProgress = false, rescanPending = true).phase(),
+        )
+    }
+
+    @Test
+    fun `running rescan is a wallet scan`() {
+        assertEquals(SyncPhase.WALLET_SCAN, snapshot(rescanInProgress = true).phase())
+    }
+
+    @Test
+    fun `nothing owed and nothing running is synced`() {
+        assertEquals(SyncPhase.SYNCED, snapshot().phase())
+    }
+
+    @Test
+    fun `blocks at the tip with filters behind is a filter sync, not synced`() {
+        assertEquals(SyncPhase.FILTERS, snapshot(filterSyncDecimal = 0.6785f).phase())
+    }
+
+    @Test
+    fun `filters still behind outranks a pending rescan`() {
+        assertEquals(
+            SyncPhase.FILTERS,
+            snapshot(filterSyncDecimal = 0.99f, rescanPending = true).phase(),
+        )
+    }
+
+    @Test
+    fun `disabled filters never hold back the synced state`() {
+        assertEquals(SyncPhase.SYNCED, snapshot(filterSyncDecimal = null).phase())
+    }
+
+    @Test
+    fun `ibd at zero progress is header sync`() {
+        assertEquals(SyncPhase.HEADERS, snapshot(ibd = true, progress = 0f).phase())
+    }
+
+    @Test
+    fun `header sync outranks a stall report`() {
+        assertEquals(
+            SyncPhase.HEADERS,
+            snapshot(ibd = true, progress = 0f, stalled = true).phase(),
+        )
+    }
+
+    @Test
+    fun `stall outranks everything once headers are in`() {
+        assertEquals(
+            SyncPhase.STALLED,
+            snapshot(stalled = true, rescanInProgress = true, rescanPending = true).phase(),
+        )
+    }
+
+    @Test
+    fun `partial block validation is a block sync`() {
+        assertEquals(SyncPhase.BLOCKS, snapshot(ibd = true, progress = 0.9998f).phase())
+    }
+
+    @Test
+    fun `still in ibd with filters at the tip falls back to blocks`() {
+        assertEquals(SyncPhase.BLOCKS, snapshot(ibd = true).phase())
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/WalletRescanGateTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/domain/floresta/WalletRescanGateTest.kt
@@ -1,0 +1,146 @@
+package com.github.jvsena42.mandacaru.domain.floresta
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+/**
+ * Virtual time throughout: the full give-up schedule spans about three hours
+ * of node uptime and is asserted here without waiting for any of it.
+ */
+class WalletRescanGateTest {
+
+    private val timeSource = TestTimeSource()
+    private val gate = WalletRescanGate(timeSource = timeSource)
+
+    private fun readyToTrigger() = gate.shouldTrigger(
+        chainFullySynced = true,
+        filtersComplete = true,
+        rescanInProgress = false,
+    )
+
+    /**
+     * The first call is what starts the grace clock — the service polls every
+     * 10s, so in practice that is the first poll after the chain reaches the
+     * tip. Leaves the gate ready to fire.
+     */
+    private fun armAndReachGrace() {
+        assertFalse(readyToTrigger())
+        timeSource += 60.seconds
+        assertTrue(readyToTrigger())
+    }
+
+    @Test
+    fun `does not fire before the grace window has elapsed`() {
+        assertFalse(readyToTrigger())
+        timeSource += 59.seconds
+        assertFalse(readyToTrigger())
+    }
+
+    @Test
+    fun `fires once the grace window has elapsed`() {
+        assertFalse(readyToTrigger())
+        timeSource += 60.seconds
+        assertTrue(readyToTrigger())
+    }
+
+    @Test
+    fun `does not fire while a rescan is already running`() {
+        assertFalse(readyToTrigger())
+        timeSource += 5.minutes
+        assertFalse(
+            gate.shouldTrigger(
+                chainFullySynced = true,
+                filtersComplete = true,
+                rescanInProgress = true,
+            )
+        )
+    }
+
+    @Test
+    fun `filters falling behind restarts the grace window`() {
+        assertFalse(readyToTrigger())
+        timeSource += 59.seconds
+        assertFalse(
+            gate.shouldTrigger(
+                chainFullySynced = true,
+                filtersComplete = false,
+                rescanInProgress = false,
+            )
+        )
+        // Filters back at the tip: the clock starts over, so the second that
+        // would have completed the original window is not enough.
+        timeSource += 1.seconds
+        assertFalse(readyToTrigger())
+        timeSource += 60.seconds
+        assertTrue(readyToTrigger())
+    }
+
+    @Test
+    fun `a failed attempt backs off twice the grace window`() {
+        armAndReachGrace()
+        assertFalse(gate.onFailed())
+
+        timeSource += 119.seconds
+        assertFalse(readyToTrigger())
+        timeSource += 1.seconds
+        assertTrue(readyToTrigger())
+    }
+
+    @Test
+    fun `backoff doubles per failure and caps at thirty minutes`() {
+        armAndReachGrace()
+
+        val expectedGaps = listOf(
+            2.minutes, 4.minutes, 8.minutes, 16.minutes, 30.minutes, 30.minutes,
+        )
+        expectedGaps.forEach { gap ->
+            assertFalse(gate.onFailed())
+            timeSource += gap - 1.seconds
+            assertFalse("expected no retry before $gap had passed", readyToTrigger())
+            timeSource += 1.seconds
+            assertTrue("expected a retry once $gap had passed", readyToTrigger())
+        }
+    }
+
+    @Test
+    fun `gives up after ten failed attempts`() {
+        armAndReachGrace()
+        repeat(9) { attempt ->
+            assertFalse("gave up early on attempt ${attempt + 1}", gate.onFailed())
+            timeSource += 30.minutes
+        }
+        assertTrue(gate.onFailed())
+    }
+
+    @Test
+    fun `a successful trigger resets the attempt budget`() {
+        armAndReachGrace()
+        repeat(9) {
+            gate.onFailed()
+            timeSource += 30.minutes
+        }
+        gate.onTriggered()
+
+        repeat(9) {
+            assertFalse(gate.onFailed())
+            timeSource += 30.minutes
+        }
+        assertTrue(gate.onFailed())
+    }
+
+    @Test
+    fun `a successful trigger also resets the backoff to the grace window`() {
+        armAndReachGrace()
+        gate.onFailed()
+        gate.onTriggered()
+
+        timeSource += 59.seconds
+        assertFalse(readyToTrigger())
+        timeSource += 1.seconds
+        assertTrue(readyToTrigger())
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationContentTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationContentTest.kt
@@ -1,0 +1,144 @@
+package com.github.jvsena42.mandacaru.presentation.service
+
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.SyncSnapshot
+import com.github.jvsena42.mandacaru.domain.floresta.phase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The foreground notification used to know only headers → blocks → stalled →
+ * synced, so it read "Fully synced" for the whole filter sync (hours) and for
+ * the whole wallet rescan while the Node screen said otherwise
+ * (jvsena42/mandacaru#103).
+ */
+class SyncNotificationContentTest {
+
+    private fun snapshot(
+        ibd: Boolean = false,
+        progress: Float = 1f,
+        filterSyncDecimal: Float? = 1f,
+        stalled: Boolean = false,
+        rescanInProgress: Boolean = false,
+        rescanPending: Boolean = false,
+    ) = SyncSnapshot(
+        ibd = ibd,
+        progress = progress,
+        filterSyncDecimal = filterSyncDecimal,
+        stalled = stalled,
+        rescanInProgress = rescanInProgress,
+        rescanPending = rescanPending,
+    )
+
+    private fun content(
+        snapshot: SyncSnapshot,
+        headerSyncDecimal: Float? = null,
+        rescanProgressDecimal: Float? = null,
+        height: Int = 947_390,
+    ) = syncNotificationContent(
+        phase = snapshot.phase(),
+        snapshot = snapshot,
+        headerSyncDecimal = headerSyncDecimal,
+        rescanProgressDecimal = rescanProgressDecimal,
+        height = height,
+    )
+
+    @Test
+    fun `does not claim synced while filters are still downloading`() {
+        val result = content(snapshot(filterSyncDecimal = 0.6785f))
+
+        assertFalse(result.synced)
+        assertEquals("Syncing filters: 67.85%", result.contentText)
+        assertEquals("67.85% filters", result.subText)
+        assertEquals(67, result.progressPercent)
+    }
+
+    @Test
+    fun `does not claim synced while a rescan is owed but not started`() {
+        val result = content(snapshot(rescanPending = true))
+
+        assertFalse(result.synced)
+        assertEquals("Scanning wallet…", result.contentText)
+        assertEquals("Finding your transactions", result.subText)
+        assertTrue(result.indeterminate)
+    }
+
+    @Test
+    fun `shows real rescan progress once the daemon reports a block total`() {
+        val result = content(
+            snapshot(rescanInProgress = true),
+            rescanProgressDecimal = 0.42f,
+        )
+
+        assertFalse(result.synced)
+        assertEquals("Scanning wallet: 42.00%", result.contentText)
+        assertEquals(42, result.progressPercent)
+        assertFalse(result.indeterminate)
+    }
+
+    @Test
+    fun `claims synced only when nothing is left to do`() {
+        val result = content(snapshot())
+
+        assertTrue(result.synced)
+        assertEquals("Synced - Block #947,390", result.contentText)
+        assertEquals("Fully synced", result.subText)
+        assertNull(result.progressPercent)
+    }
+
+    @Test
+    fun `header sync shows peer-derived progress when available`() {
+        val result = content(
+            snapshot(ibd = true, progress = 0f),
+            headerSyncDecimal = 0.5f,
+        )
+
+        assertEquals("Syncing headers: 50.00%", result.contentText)
+        assertEquals(50, result.progressPercent)
+    }
+
+    @Test
+    fun `header sync without peers is indeterminate`() {
+        val result = content(snapshot(ibd = true, progress = 0f))
+
+        assertEquals("Syncing headers…", result.contentText)
+        assertEquals("Connecting to peers", result.subText)
+        assertTrue(result.indeterminate)
+    }
+
+    @Test
+    fun `block sync reports the validation percentage`() {
+        val result = content(snapshot(ibd = true, progress = 0.9998f))
+
+        assertEquals("Syncing blocks: 99.98%", result.contentText)
+        assertEquals("99.98% blocks", result.subText)
+    }
+
+    @Test
+    fun `stalled sync names the height it is stuck at and shows no bar`() {
+        val result = content(snapshot(stalled = true), height = 17_904)
+
+        assertFalse(result.synced)
+        assertEquals("Sync stalled at block #17,904", result.contentText)
+        assertEquals("Storage may be unhealthy", result.subText)
+        assertNull(result.progressPercent)
+        assertFalse(result.indeterminate)
+    }
+
+    @Test
+    fun `synced is the only phase that reports synced`() {
+        SyncPhase.entries.forEach { phase ->
+            val result = syncNotificationContent(
+                phase = phase,
+                snapshot = snapshot(),
+                headerSyncDecimal = null,
+                rescanProgressDecimal = null,
+                height = 947_390,
+            )
+            assertEquals("$phase reported the wrong synced state", phase == SyncPhase.SYNCED, result.synced)
+        }
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationParityTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/service/SyncNotificationParityTest.kt
@@ -1,0 +1,94 @@
+package com.github.jvsena42.mandacaru.presentation.service
+
+import com.github.jvsena42.mandacaru.domain.floresta.SyncSnapshot
+import com.github.jvsena42.mandacaru.domain.floresta.phase
+import com.github.jvsena42.mandacaru.presentation.ui.screens.node.computeSyncStepStates
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The foreground notification and the Node screen's stepper are two views of
+ * the same state and used to derive it independently — they disagreed for
+ * hours at a time (jvsena42/mandacaru#103). This walks every combination and
+ * asserts they still agree on the one thing that matters: are we done?
+ */
+class SyncNotificationParityTest {
+
+    @Test
+    fun `notification and node screen agree on being fully synced`() {
+        var checked = 0
+        forEachSnapshot { snapshot ->
+            val phase = snapshot.phase()
+            val notification = syncNotificationContent(
+                phase = phase,
+                snapshot = snapshot,
+                headerSyncDecimal = null,
+                rescanProgressDecimal = null,
+                height = 947_390,
+            )
+            val steps = computeSyncStepStates(
+                phase = phase,
+                syncDecimal = snapshot.progress,
+                filterSyncDecimal = snapshot.filterSyncDecimal,
+            )
+            assertEquals(
+                "disagreed on $snapshot",
+                steps.allDone,
+                notification.synced,
+            )
+            checked++
+        }
+        assertEquals(EXPECTED_COMBINATIONS, checked)
+    }
+
+    @Test
+    fun `every surface stays unsynced whenever a rescan is owed or running`() {
+        forEachSnapshot { snapshot ->
+            if (!snapshot.rescanPending && !snapshot.rescanInProgress) return@forEachSnapshot
+            val phase = snapshot.phase()
+            val notification = syncNotificationContent(
+                phase = phase,
+                snapshot = snapshot,
+                headerSyncDecimal = null,
+                rescanProgressDecimal = null,
+                height = 947_390,
+            )
+            val steps = computeSyncStepStates(
+                phase = phase,
+                syncDecimal = snapshot.progress,
+                filterSyncDecimal = snapshot.filterSyncDecimal,
+            )
+            assertEquals("notification claimed synced for $snapshot", false, notification.synced)
+            assertEquals("node screen claimed synced for $snapshot", false, steps.allDone)
+        }
+    }
+
+    private fun forEachSnapshot(block: (SyncSnapshot) -> Unit) {
+        listOf(false, true).forEach { ibd ->
+            listOf(0f, 0.5f, 0.9998f, 1f).forEach { progress ->
+                listOf(null, 0f, 0.6785f, 1f).forEach { filters ->
+                    listOf(false, true).forEach { stalled ->
+                        listOf(false, true).forEach { rescanInProgress ->
+                            listOf(false, true).forEach { rescanPending ->
+                                block(
+                                    SyncSnapshot(
+                                        ibd = ibd,
+                                        progress = progress,
+                                        filterSyncDecimal = filters,
+                                        stalled = stalled,
+                                        rescanInProgress = rescanInProgress,
+                                        rescanPending = rescanPending,
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val EXPECTED_COMBINATIONS = 2 * 4 * 4 * 2 * 2 * 2
+    }
+}

--- a/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModelSyncStateTest.kt
+++ b/app/src/test/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModelSyncStateTest.kt
@@ -1,0 +1,151 @@
+package com.github.jvsena42.mandacaru.presentation.ui.screens.node
+
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+import com.github.jvsena42.mandacaru.data.network.NetworkPolicy
+import com.github.jvsena42.mandacaru.domain.floresta.FlorestaDaemon
+import com.github.jvsena42.mandacaru.domain.floresta.SyncPhase
+import com.github.jvsena42.mandacaru.domain.floresta.UtreexoSnapshotService
+import com.github.jvsena42.mandacaru.domain.floresta.phase
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.GetBlockchainInfoResponse
+import com.github.jvsena42.mandacaru.fakes.FakeFlorestaRpc
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import com.github.jvsena42.mandacaru.domain.model.florestaRPC.response.Result as BlockchainInfo
+
+/**
+ * Covers the P2 half of jvsena42/mandacaru#103: a rescan armed by a descriptor
+ * load isn't fired until the chain has been at the tip for a grace window, and
+ * until it has, the screen must not report being fully synced.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NodeViewModelSyncStateTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var rpc: FakeFlorestaRpc
+    private lateinit var preferences: FakePreferences
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        rpc = FakeFlorestaRpc()
+        preferences = FakePreferences()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a pending rescan keeps the screen out of the synced state`() {
+        preferences.setBooleanNow(PreferenceKeys.WALLET_NEEDS_RESCAN, true)
+        rpc.blockchainInfoResults = listOf(Result.success(syncedResponse()))
+
+        val state = buildViewModelAndPoll()
+
+        assertTrue(state.walletRescanPending)
+        assertFalse(state.rescanInProgress)
+        assertEquals(SyncPhase.WALLET_SCAN, state.toSyncSnapshot().phase())
+        assertFalse(
+            computeSyncStepStates(
+                phase = state.toSyncSnapshot().phase(),
+                syncDecimal = state.syncDecimal,
+                filterSyncDecimal = state.filterSyncDecimal,
+            ).allDone
+        )
+    }
+
+    @Test
+    fun `the same state without a pending rescan is fully synced`() {
+        rpc.blockchainInfoResults = listOf(Result.success(syncedResponse()))
+
+        val state = buildViewModelAndPoll()
+
+        assertFalse(state.walletRescanPending)
+        assertEquals(SyncPhase.SYNCED, state.toSyncSnapshot().phase())
+        assertTrue(
+            computeSyncStepStates(
+                phase = state.toSyncSnapshot().phase(),
+                syncDecimal = state.syncDecimal,
+                filterSyncDecimal = state.filterSyncDecimal,
+            ).allDone
+        )
+    }
+
+    private fun buildViewModelAndPoll(): NodeUiState {
+        val vm = NodeViewModel(
+            florestaRpc = rpc,
+            snapshotService = FakeSnapshotService(FakeFlorestaDaemon()),
+            florestaDaemon = FakeFlorestaDaemon(),
+            preferencesDataSource = preferences,
+            networkPolicyManager = FakeNetworkPolicy(),
+            peerCountryLookup = { null },
+            ioDispatcher = dispatcher,
+        )
+        dispatcher.scheduler.runCurrent()
+        return vm.uiState.value
+    }
+
+    private fun syncedResponse() = GetBlockchainInfoResponse(
+        id = 1,
+        jsonrpc = "2.0",
+        result = BlockchainInfo(
+            bestBlock = "00".repeat(32),
+            chain = "bitcoin",
+            difficulty = 1f,
+            height = 947_390,
+            ibd = false,
+            latestBlockTime = 0,
+            latestWork = "0",
+            leafCount = 0,
+            progress = 1f,
+            rootCount = 0,
+            rootHashes = emptyList(),
+            validated = 947_390,
+            filters = 947_390,
+            filtersStart = 0,
+            rescanInProgress = false,
+        ),
+    )
+
+    // --- fakes ---
+
+    private class FakePreferences : PreferencesDataSource {
+        private val strings = mutableMapOf<PreferenceKeys, String>()
+        private val booleans = mutableMapOf<PreferenceKeys, Boolean>()
+        fun setBooleanNow(key: PreferenceKeys, value: Boolean) { booleans[key] = value }
+        override suspend fun setString(key: PreferenceKeys, value: String) { strings[key] = value }
+        override suspend fun getString(key: PreferenceKeys, defaultValue: String): String =
+            strings[key] ?: defaultValue
+        override suspend fun setBoolean(key: PreferenceKeys, value: Boolean) { booleans[key] = value }
+        override suspend fun getBoolean(key: PreferenceKeys, defaultValue: Boolean): Boolean =
+            booleans[key] ?: defaultValue
+    }
+
+    private class FakeSnapshotService(daemon: FlorestaDaemon) : UtreexoSnapshotService(daemon)
+
+    private class FakeFlorestaDaemon : FlorestaDaemon {
+        override suspend fun start() = Unit
+        override suspend fun stop() = Unit
+        override fun isRunning(): Boolean = false
+        override suspend fun dumpUtreexoState(): Result<String> = Result.success("")
+        override suspend fun prepareForSnapshotImport(): Result<Unit> = Result.success(Unit)
+    }
+
+    private class FakeNetworkPolicy : NetworkPolicy {
+        override val isWaitingForWifi: StateFlow<Boolean> = MutableStateFlow(false)
+        override fun apply() = Unit
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **P2** of #103, plus a worse sibling found while auditing it: the foreground-service notification and the Node screen disagreed about how synced we are.

**P2.** `SettingsViewModel` arms `WALLET_NEEDS_RESCAN` on descriptor load (`:451`) and birthday change (`:313`), but `FlorestaService` only fires the rescan 60s after filters reach the tip. The stepper's `allDone` consulted only `rescan_in_progress`, so for at least that minute — plus up to 10s of poll latency — the UI reported 100% with a rescan still pending. That is what put @TheButterZone in a position to reconnect their Electrum wallets at step 20 when it wasn't yet safe to.

**The notification was worse.** `applySyncState` knew only headers → blocks → stalled → synced. With no filters phase and no rescan phase *at all*, it read `Synced - Block #N` / "Fully synced" through the entire compact-filter sync — ~3 hours in the reporter's log (steps 11→13) — and through a running rescan, while the Node screen correctly said "Syncing filters" / "Scanning wallet".

The root cause of the drift: the phase logic existed in three hand-rolled copies (`ScreenNode`, `ScreenNodeTablet`, `FlorestaService`).

## What changed

- **`domain/floresta/SyncPhase.kt`** — one pure phase computation shared by all three surfaces. `WALLET_SCAN` now covers a rescan that is *pending* as well as one in flight. Precedence preserves today's phone-screen title order exactly. Also holds `computeFilterSyncDecimal` / `computeRescanProgressDecimal`, so the screen and the service stop computing them differently.
- **`presentation/service/SyncNotificationContent.kt`** — maps a phase to notification text, free of Android types so it is unit-testable. `synced = (phase == SYNCED)` is the one line that makes "Fully synced" impossible during filters or a rescan.
- **`domain/floresta/WalletRescanGate.kt`** — the service's grace-window state, plus a retry bound. Since the UI now stays unsynced while the flag is set, a rescan that can never succeed (e.g. `NoBlockFilters`) would otherwise pin it there forever. Ten attempts, backoff doubling from 60s to a 30m cap, then it clears the flag. Timing uses a monotonic `TimeSource`, not the wall clock — an NTP correction mid-session would otherwise make a long backoff fire instantly or never.
- `ScreenNodeTablet` now takes a `SyncPhase` instead of five derived booleans, so it can't be handed an inconsistent set.

Note `rescanblockchain` flips `rescan_in_progress` synchronously before returning `Ok`, so clearing the flag right after a successful RPC leaves no gap where both pending and in-progress read false.

## Tests

42 new tests (331 total). Beyond the per-phase cases, `SyncNotificationParityTest` walks all 256 combinations of `ibd × progress × filters × rescan × pending × stalled` and asserts the notification's `synced` flag equals the stepper's `allDone` — that is what fails today and what stops the two surfaces drifting again.

Reverting just the P2 condition (`rescanInProgress || rescanPending` → `rescanInProgress`) fails exactly four tests, one per surface, confirming they are load-bearing.

## Verified on device

Mainnet emulator at height 959,254. With `ibd=false, progress=1.0` and filters at 2.5%:

| Surface | Before | After |
| --- | --- | --- |
| Node screen | Syncing filters 2.83% | Syncing filters 2.83% |
| Notification | **Synced - Block #959,254 / Fully synced** | Syncing filters: 2.52% |

Also confirmed `WALLET_NEEDS_RESCAN` arms on descriptor load (read back from DataStore), and that with it armed while filters are at 12.67% both surfaces still correctly show "Syncing filters" — a pending rescan must not preempt a phase that has to finish first.

## Scope

P1, P3 and P4 of #103 remain open; P1 and P4 are filed upstream (getfloresta/Floresta#1225, #1226).

## Checklist

- [x] Commits are atomic and follow conventional style (`feat:`, `fix:`, `chore:`, ...)
- [x] Unit tests added/updated for business-logic changes
- [x] Journeys and `journeys/README.md` testTags updated for UI changes — N/A, no testTags added or renamed
- [x] `./gradlew detekt`, `./gradlew lintDebug`, and `./gradlew test` pass locally
- [x] I have self-reviewed my own diff

## Preview

Text-only change to sync labels; the before/after notification text is in the table above.