### PR TITLE
feat: gate network selection behind advanced features

### DIFF
--- a/app/src/main/java/com/github/jvsena42/mandacaru/domain/settings/AdvancedFeaturesSetting.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/domain/settings/AdvancedFeaturesSetting.kt
@@ -1,0 +1,19 @@
+package com.github.jvsena42.mandacaru.domain.settings
+
+import com.github.jvsena42.mandacaru.BuildConfig
+import com.github.jvsena42.mandacaru.data.PreferenceKeys
+import com.github.jvsena42.mandacaru.data.PreferencesDataSource
+
+/**
+ * Advanced features are off for released builds and on everywhere else, so development
+ * builds surface the network selector, peer flags and developer tools without a manual
+ * opt-in on every fresh install.
+ */
+val ADVANCED_FEATURES_ENABLED_BY_DEFAULT = BuildConfig.DEBUG
+
+/**
+ * Single source of truth for the advanced-features preference, shared by every screen that
+ * gates UI on it so they can never disagree about whether the feature is on.
+ */
+suspend fun PreferencesDataSource.isAdvancedFeaturesEnabled(): Boolean =
+    getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, ADVANCED_FEATURES_ENABLED_BY_DEFAULT)

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeUiState.kt
@@ -2,6 +2,7 @@ package com.github.jvsena42.mandacaru.presentation.ui.screens.node
 
 import androidx.compose.runtime.Stable
 import com.github.jvsena42.mandacaru.domain.floresta.SnapshotPreview
+import com.github.jvsena42.mandacaru.domain.settings.ADVANCED_FEATURES_ENABLED_BY_DEFAULT
 
 @Stable
 data class NodeUiState(
@@ -30,7 +31,7 @@ data class NodeUiState(
     val peers: List<PeerUi> = emptyList(),
     val utreexoPeerCount: Int = 0,
     val isPeersExpanded: Boolean = false,
-    val enableAdvancedFeatures: Boolean = false,
+    val enableAdvancedFeatures: Boolean = ADVANCED_FEATURES_ENABLED_BY_DEFAULT,
     val uptime: String = "",
     val isDiagnosticsExpanded: Boolean = false,
 

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/node/NodeViewModel.kt
@@ -18,6 +18,7 @@ import com.github.jvsena42.mandacaru.domain.floresta.computeRescanProgressDecima
 import com.github.jvsena42.mandacaru.domain.floresta.hasUtreexoServiceFlag
 import com.github.jvsena42.mandacaru.domain.floresta.isLikelyStalled
 import com.github.jvsena42.mandacaru.domain.geoip.PeerCountryLookup
+import com.github.jvsena42.mandacaru.domain.settings.isAdvancedFeaturesEnabled
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
 import com.github.jvsena42.mandacaru.presentation.utils.HexUtils
@@ -70,8 +71,7 @@ class NodeViewModel(
     }
 
     private suspend fun refreshPreferences() {
-        val enabled = preferencesDataSource
-            .getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, false)
+        val enabled = preferencesDataSource.isAdvancedFeaturesEnabled()
         // A rescan armed by a descriptor load or birthday change only fires
         // once the chain has been at the tip for a grace window. Until it
         // does, the wallet still has history to find and we must not claim

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/ScreenSettings.kt
@@ -495,65 +495,67 @@ private fun ScreenSettings(
                 }
 
                 // Network Section
-                item {
-                    SectionCard(
-                        title = stringResource(R.string.network),
-                        icon = Icons.Outlined.NetworkCheck,
-                        isExpanded = uiState.isNetworkExpanded,
-                        onToggle = { onAction(SettingsAction.ToggleNetworkExpanded) },
-                        modifier = Modifier.animateItem(),
-                    ) {
-                        Column(modifier = Modifier.fillMaxWidth()) {
-                            var expanded by remember { mutableStateOf(false) }
+                if (uiState.enableAdvancedFeatures) {
+                    item {
+                        SectionCard(
+                            title = stringResource(R.string.network),
+                            icon = Icons.Outlined.NetworkCheck,
+                            isExpanded = uiState.isNetworkExpanded,
+                            onToggle = { onAction(SettingsAction.ToggleNetworkExpanded) },
+                            modifier = Modifier.animateItem(),
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                var expanded by remember { mutableStateOf(false) }
 
-                            ExposedDropdownMenuBox(
-                                expanded = expanded,
-                                onExpandedChange = { expanded = !expanded }
-                            ) {
-                                OutlinedTextField(
-                                    value = uiState.selectedNetwork,
-                                    readOnly = true,
-                                    onValueChange = { },
-                                    label = { Text(stringResource(R.string.select_a_network)) },
-                                    trailingIcon = {
-                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                                    },
-                                    shape = RoundedCornerShape(12.dp),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .menuAnchor()
-                                        .testTag("input_network")
-                                )
-
-                                ExposedDropdownMenu(
+                                ExposedDropdownMenuBox(
                                     expanded = expanded,
-                                    onDismissRequest = { expanded = false }
+                                    onExpandedChange = { expanded = !expanded }
                                 ) {
-                                    uiState.network.forEach { network ->
-                                        DropdownMenuItem(
-                                            text = { Text(network.name) },
-                                            onClick = {
-                                                onAction(SettingsAction.OnNetworkSelected(network.name))
-                                                expanded = false
-                                            }
-                                        )
+                                    OutlinedTextField(
+                                        value = uiState.selectedNetwork,
+                                        readOnly = true,
+                                        onValueChange = { },
+                                        label = { Text(stringResource(R.string.select_a_network)) },
+                                        trailingIcon = {
+                                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                                        },
+                                        shape = RoundedCornerShape(12.dp),
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .menuAnchor()
+                                            .testTag("input_network")
+                                    )
+
+                                    ExposedDropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = { expanded = false }
+                                    ) {
+                                        uiState.network.forEach { network ->
+                                            DropdownMenuItem(
+                                                text = { Text(network.name) },
+                                                onClick = {
+                                                    onAction(SettingsAction.OnNetworkSelected(network.name))
+                                                    expanded = false
+                                                }
+                                            )
+                                        }
                                     }
                                 }
-                            }
 
-                            Spacer(modifier = Modifier.height(12.dp))
+                                Spacer(modifier = Modifier.height(12.dp))
 
-                            Card(
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                                )
-                            ) {
-                                Text(
-                                    stringResource(R.string.the_application_will_be_restarted_to_update_the_network),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                    modifier = Modifier.padding(12.dp)
-                                )
+                                Card(
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                    )
+                                ) {
+                                    Text(
+                                        stringResource(R.string.the_application_will_be_restarted_to_update_the_network),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                        modifier = Modifier.padding(12.dp)
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsUiState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import com.florestad.Network
 import com.github.jvsena42.mandacaru.domain.geoip.PEER_FLAGS_ENABLED_BY_DEFAULT
 import com.github.jvsena42.mandacaru.domain.model.UpdateStatus
+import com.github.jvsena42.mandacaru.domain.settings.ADVANCED_FEATURES_ENABLED_BY_DEFAULT
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
 import com.github.jvsena42.mandacaru.presentation.utils.WalletBirthday
 
@@ -44,7 +45,7 @@ data class SettingsUiState(
     val rescanBlocksTotal: Int? = null,
     val useAlsoMobileData: Boolean = false,
     val isDataUsageExpanded: Boolean = false,
-    val enableAdvancedFeatures: Boolean = false,
+    val enableAdvancedFeatures: Boolean = ADVANCED_FEATURES_ENABLED_BY_DEFAULT,
     val isPeerFlagsEnabled: Boolean = PEER_FLAGS_ENABLED_BY_DEFAULT,
     val isPeerFlagsExpanded: Boolean = false,
     val isDeveloperToolsExpanded: Boolean = false,

--- a/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jvsena42/mandacaru/presentation/ui/screens/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.github.jvsena42.mandacaru.domain.geoip.isPeerFlagsEnabled
 import com.github.jvsena42.mandacaru.domain.model.florestaRPC.AddNodeCommand
 import com.github.jvsena42.mandacaru.domain.scan.DescriptorQrScanner
 import com.github.jvsena42.mandacaru.domain.scan.DescriptorScanState
+import com.github.jvsena42.mandacaru.domain.settings.isAdvancedFeaturesEnabled
 import com.github.jvsena42.mandacaru.presentation.utils.DescriptorUtils
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlow
 import com.github.jvsena42.mandacaru.presentation.utils.EventFlowImpl
@@ -64,8 +65,7 @@ class SettingsViewModel(
                 ?: WalletBirthday.defaultYear()
             val useAlsoMobileData = preferencesDataSource
                 .getBoolean(PreferenceKeys.USE_ALSO_MOBILE_DATA, false)
-            val enableAdvancedFeatures = preferencesDataSource
-                .getBoolean(PreferenceKeys.ENABLE_ADVANCED_FEATURES, false)
+            val enableAdvancedFeatures = preferencesDataSource.isAdvancedFeaturesEnabled()
             val isPeerFlagsEnabled = preferencesDataSource.isPeerFlagsEnabled()
             _uiState.update {
                 it.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="export_logs">Export</string>
     <string name="share_logs">Share Logs</string>
     <string name="advanced_features">Advanced features</string>
-    <string name="advanced_features_subtitle">Show developer tools such as the node log viewer</string>
+    <string name="advanced_features_subtitle">Show extra settings and tools for advanced users</string>
     <string name="developer_tools">Developer Tools</string>
     <string name="view_logs">View logs</string>
     <string name="copy_logs">Copy logs</string>

--- a/journeys/README.md
+++ b/journeys/README.md
@@ -145,10 +145,10 @@ action) on open. The snackbar is part of the Scaffold subtree, so its text and a
 | `tab_extended_key`         | "Extended key" tab inside the share sheet (see popup caveat) |
 | `button_copy_descriptor`    | Copy button on the share sheet's Descriptor tab |
 | `button_copy_extended_key`  | Copy button on the share sheet's Extended-key tab |
-| `input_network`             | network selector field                 |
+| `input_network`             | network selector field — inside the Network section, only when advanced features are on |
 | `toggle_mobile_data`        | "Also use mobile data" switch          |
 | `toggle_peer_flags`         | "Peer country flags" switch — inside its own expandable section, only when advanced features are on |
-| `toggle_advanced_features`  | "Advanced features" switch (gates the Developer Tools section) |
+| `toggle_advanced_features`  | "Advanced features" switch (gates the Network, Peer country flags and Developer Tools sections) |
 | `button_view_logs`          | "View logs" (opens the full-screen log viewer) |
 | `button_export_logs`        | "Export" (share the full debug.log) — inside Developer Tools |
 
@@ -178,15 +178,20 @@ first, then expand "Peer country flags" by text before the switch surfaces. Unli
 switches it is **on** by default. Turning it off stops the monthly database download and removes
 `node_peer_flag` from every peer row within one 10-second poll, with no restart.
 
-`toggle_advanced_features` is off by default. The **Developer Tools** section (and its
-`button_view_logs` / `button_export_logs`) only renders once the toggle is on. Expand
+`toggle_advanced_features` defaults to **on in debug builds and off in release builds**, so on the
+debug build journeys run against, the gated sections are visible without touching it — but a
+journey that depends on them should still confirm the switch is on (it persists across restarts,
+so a previous run may have turned it off). The **Network**, **Peer country flags** and **Developer
+Tools** sections only render while the toggle is on. Expand
 "Developer Tools" by text, then tap `button_view_logs` to open `ScreenDeveloperLogs` — a
 full-screen Nav3 destination in the root subtree, so its tags surface normally (the popup
 caveat does **not** apply). There: `button_back_logs` returns to Settings, `button_copy_logs`
 copies the displayed tail, and the share action reuses `button_export_logs`. Each log line
 is colored by level (ERROR/WARN/INFO/DEBUG/TRACE).
 
-Tapping `input_network` opens the network dropdown. Its options are **targeted by text**
+The **Network** section only renders while `toggle_advanced_features` is on, so turn advanced
+features on first, then expand "Network" by text before `input_network` surfaces. Tapping
+`input_network` opens the network dropdown. Its options are **targeted by text**
 (`BITCOIN`, `SIGNET`, `TESTNET`, `REGTEST`, `TESTNET4`) — see the popup caveat below.
 
 ## Popups, dropdowns, and dialogs

--- a/journeys/switch_network.xml
+++ b/journeys/switch_network.xml
@@ -6,6 +6,7 @@
     <actions>
         <action>Launch the Mandacaru app and wait for the splash screen to dismiss (poll until nav_node is present)</action>
         <action>Tap the Settings navigation item (nav_settings)</action>
+        <action>Scroll to the Advanced features switch (toggle_advanced_features) and turn it on if it is off — the Network section only renders while it is on</action>
         <action>Expand the Network section if it is collapsed</action>
         <action>Tap the network selector field (input_network)</action>
         <action>Tap the SIGNET option in the dropdown (target it by its text)</action>


### PR DESCRIPTION
## What

Hides the **Network** section in Settings behind the existing **Advanced features** switch, and makes that switch default to **on in debug builds / off in release builds**.

## Why

Switching networks restarts the node onto a chain most users never want, so it belongs with the other advanced-only sections (peer country flags, developer tools). Defaulting the flag on outside release builds means development and journey-test builds surface the gated sections without a manual opt-in on every fresh install.

## Changes

- **New** `domain/settings/AdvancedFeaturesSetting.kt`: `ADVANCED_FEATURES_ENABLED_BY_DEFAULT = BuildConfig.DEBUG` plus a shared `PreferencesDataSource.isAdvancedFeaturesEnabled()` — same shape as the existing `PeerFlagsSetting`, so no screen can disagree about the default.
- `SettingsViewModel` / `NodeViewModel` read the preference through that helper; `SettingsUiState` / `NodeUiState` use the same constant as their initial value.
- `ScreenSettings.kt`: the Network `SectionCard` is wrapped in `if (uiState.enableAdvancedFeatures)`.
- `strings.xml`: the advanced-features subtitle is now generic ("Show extra settings and tools for advanced users") instead of naming only the log viewer.
- `journeys/README.md`: documents that `toggle_advanced_features` now gates Network too, and the debug-on/release-off default.
- `journeys/switch_network.xml`: turns the advanced-features switch on before expanding Network (the preference persists, so a previous run may have left it off).

## Verification

`./gradlew assembleDebug detekt lintDebug` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)